### PR TITLE
Modificando a variável ama_header

### DIFF
--- a/post_proc.py
+++ b/post_proc.py
@@ -3,7 +3,7 @@ in_text = in_file.read().lstrip()
 in_text_slice = in_text.splitlines()
 
 linhas_apagar = []  # slice de linhas a ser apagadas ao final.
-ama_header = in_text_slice[0].split()[0]
+ama_header = in_text_slice[0]
 ama_header_count = 0
 codigo_count = 0
 codigo_total = in_text.count("Código Identificador")


### PR DESCRIPTION
Modifiquei a variável para a verificação das linhas que contém o cabeçalho ser feito com o cabeçalho todo, ao invés da primeira palavra.

O texto de saída (processado) deu o **exato mesmo resultado** e por conta disso nem contou como commit, pois não teve nenhuma alteração