### PR TITLE
RESOLVE: Issue #17 [bug] número de arquivos gerados é maior que número de municípios

### DIFF
--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
@@ -1,5 +1,2906 @@
-Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+ESTADO DE ALAGOAS 
+PREFEITURA MUNICIPAL DE MARAGOGI 
 
+ 
+SECRETARIA MUNICIPAL DE RELAÇÕES INSTITUCIONAIS 
+
+LEI MUNICIPAL Nº 763/2022 
+ 
+(De 30 de junho de 2022) 
+
+  
+DISPÕE SOBRE AS DIRETRIZES ORÇAMENTÁRIAS PARA ELABORAÇÃO E EXECUÇÃO DO ORÇAMENTO PARA O EXERCÍCIO FINANCEIRO DE 2023 E DÁ OUTRAS 
+PROVIDÊNCIAS. 
+
+  
+O PREFEITO DO MUNICÍPIO DE MARAGOGI, Estado de Alagoas, no uso de suas atribuições legais conferidas pela Lei Orgânica Municipal, Lei nº 099/90, de 05 de abril de 1990 e pela Constituição Federal, 
+faz saber que a Câmara Municipal de Vereadores aprovou e eu sanciono a seguinte Lei: 
+  
+CAPÍTULO I 
+Seção I 
+Das Disposições Preliminares 
+  
+Art. 1º - Ficam estabelecidas, em cumprimento ao dispositivo no art. 165, § 2o, da Constituição Federal e na Lei Complementar Federal nº 101, de 04 de maio de 2000 (Lei de Responsabilidade Fiscal – LRF) as 
+diretrizes para elaboração dos Orçamentos para o exercício de 2023, compreendendo: 
+I – As Metas e Prioridades da Administração Pública Municipal; II – As Metas e Riscos Fiscais; 
+III – A Estrutura e as Diretrizes dos Orçamentos; 
+IV – As Diretrizes para Execução dos Orçamentos; 
+V – As Diretrizes sobre Alterações na Legislação Tributária; 
+VI- As Disposições Relativas às Despesas com Pessoal; 
+VII – Do Não Atingimento das Metas Fiscais; 
+VIII - Do Regime Próprio de Previdência Social – RPPS; 
+IX – As Disposições Relativas à Dívida Pública Municipal; 
+X - A Transparência da Gestão Fiscal; 
+XI – As Disposições Gerais; 
+XII – Anexo I de Metas Fiscais; 
+XIII – Anexo II de Riscos Fiscais. 
+Art. 2º - Entende-se por Diretrizes Orçamentárias as instruções e orientações para elaboração e execução dos orçamentos para o exercício financeiro de 2023. 
+Seção II 
+Dos Gastos Municipais 
+
+  
+Art. 3º - Constituem gastos municipais aqueles destinados à aquisição de materiais, bens e serviços para cumprimento dos objetivos do Município, bem como os compromissos de natureza social e financeira. 
+Art. 4º - Os gastos municipais serão estimados por serviços mantidos pelo Município, considerando-se: 
+I – Carga de trabalho estimada para o exercício financeiro; 
+II – Fatores conjunturais que possam afetar os gastos; 
+III – Recursos destinados ao pagamento e parcelamento da Dívida Fundada; 
+IV – Recursos destinados ao pagamento de sentenças judiciais; 
+Seção III 
+Das Receitas do Município 
+
+  
+Art. 5º - Constituem Receitas do Município aquelas provenientes: 
+I – Dos tributos de sua competência; 
+II – De atividades econômicas; 
+III – De transferências constitucionais ou voluntárias; 
+IV – Das alienações; 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     30 
+ 
+
+V – Dos empréstimos e financiamentos autorizados por Lei, destinados à despesa de capital; 
+VI – Das contribuições sociais para o Regime Próprio de Previdência Social. 
+Art. 6º - Para fins de estimativa das receitas será considerado: 
+I – Os fatores conjunturais que passam vir a influenciar a produtividade de cada fonte: 
+II – A carga de trabalho estimada para o serviço, quando este for remunerado; 
+III – Alterações na legislação tributária; 
+IV – A variação do índice de preços; 
+V – A arrecadação dos últimos 04 (quatro) exercícios encerrados (2018 a 2021) e a previsão de 2022. 
+Art. 7º - O Município fica obrigado a arrecadar todos os impostos de sua competência; 
+§1º - O Município despenderá esforços no sentido de diminuir o valor da dívida ativa: 
+§2º - O Município procurará modernizar a máquina fazendária no sentido de aumentar a arrecadação; 
+§3º - A Lei que conceda ou amplie incentivos ou benefícios de natureza tributária só poderá ser aprovada ou editada se cumpridas as exigências do Art. 14 da Lei Complementar nº 101/2000. 
+§4º - Qualquer alteração na Legislação Tributária para o exercício financeiro de 2023 deverá ser encaminhada ao Poder Legislativo e por ele aprovada antes da elaboração do Projeto de Lei Orçamentária, a fim de 
+que possas as mesmas ser incluídas na previsão da receita. 
+  
+CAPÍTULO II 
+DAS METAS E DAS PRIORIDADES DA ADMINISTRAÇÃO PÚBLICA MUNICIPAL 
+  
+Art. 8º - A Administração Pública Municipal elegeu como Prioridades e Metas para o exercício de 2023 as Ações extraídas do Plano Plurianual para o período de 2022-2025, que integrarão os anexos desta Lei. 
+§ 1º - As Prioridades e Metas de que trata este artigo terão precedência na alocação de recursos na Lei Orçamentária Anual de 2023 e na sua execução, não se constituindo em limite à programação da despesa, 
+respeitando o atendimento das despesas que constituem obrigações constitucionais. 
+§ 2º Poderá ser procedida a adequação das Prioridades e Metas de que trata o caput deste artigo, se durante o período de apreciação da proposta orçamentária para 2023, surgirem novas demandas e/ou situações em 
+que haja necessidade da intervenção do Poder Público, ou em decorrência de créditos adicionais ocorridos. 
+Art. 9º - As ações constantes no Anexo de que trata o artigo anterior possuem caráter indicativo e não normativo, devendo servir de referência para o planejamento, sendo automaticamente atualizados pela Lei 
+Orçamentária e respectivos créditos adicionais, com atualização automática nos valores previstos no Plano Plurianual. 
+§ 1º - Quando da elaboração do Projeto de Lei Orçamentária para 2023, ambos os Poderes deverão verificar os programas que forem contemplados no PPA (2022-2025), e as ações prioritárias nele contempladas para 
+2023 deverão estar em consonância com as prioridades e metas previstas na presente Lei. 
+§ 2º - Quando da elaboração do Projeto de Lei Orçamentária Anual para 2023, o Poder Executivo e Poder Legislativo deverão obedecer aos atos normativos que estiverem vigentes. 
+Art. 10º - A elaboração e a aprovação do Projeto de Lei Orçamentária Anual – PLOA para o exercício de 2023, bem como a execução da respectiva Lei, deverão ser compatíveis com a obtenção das metas constantes 
+dos anexos desta Lei. 
+CAPÍTULO III 
+DAS METAS E RISCOS FISCAIS 
+  
+Art. 11º - Integram esta Lei os Anexos referenciados nos §§ 1º e 3º do art. 4º da Lei Complementar nº 101, de 2000. 
+Parágrafo único - A elaboração do Projeto de Lei e a execução da Lei Orçamentária Anual para o exercício financeiro de 2023 deverão levar em conta as metas de resultado primário e nominal estabelecidas no 
+Anexo de Metas Fiscais constante desta Lei. 
+Art. 12º - Estão discriminados, em Anexo integrante desta Lei, os Riscos Fiscais, nos quais são avaliados os passivos contingentes e outros riscos capazes de afetar as contas públicas. 
+CAPÍTULO IV 
+DA ESTRUTURA E DAS DIRETRIZES DOS ORÇAMENTOS 
+Seção I 
+Da Organização dos Orçamentos 
+  
+Art. 13º - A Lei Orçamentária compor-se-á de: 
+I – Orçamento Fiscal; 
+II – Orçamento da Seguridade Social; 
+§ 1º - O Orçamento Fiscal tratará da política fiscal e abrangerá os Poderes Executivo e Legislativo, seus fundos, órgãos, autarquias e fundações instituídas e mantidas pelo Poder Público. 
+§ 2º - O Orçamento da Seguridade Social abrangerá as áreas de Saúde e Assistência Social. 
+Art. 14º - A estrutura do Projeto de Lei do Orçamento Anual deverá identificar a receita por origem e esfera orçamentária e a despesa por função, subfunção, programa de governo, ação orçamentária, fonte de 
+recursos e esfera orçamentária. 
+§ 1º - Os Programas, para atingir os seus objetivos, se desdobram em ações orçamentárias. 
+§ 2º - As ações, agrupadas por unidade orçamentária, compreendem atividades, projetos e operações especiais. 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     31 
+ 
+
+§ 3º - As ações orçamentárias dos Orçamentos Fiscal e da Seguridade Social, citadas no §1º deste artigo, de acordo com a finalidade do gasto, serão classificadas como: 
+I – Atividades de pessoal e encargos sociais; 
+II – Atividades de manutenção administrativa; 
+III – Outras atividades de caráter obrigatório; 
+IV – Atividades finalísticas; e 
+V – Projetos. 
+§ 4º - Os conceitos de função, subfunção, programa, projeto, atividade e operação especial são os previstos na Portaria nº 42, de 14 de abril de 1999, do Ministério do Planejamento, Orçamento e Gestão, com suas 
+posteriores alterações. 
+Art. 15º - A Lei Orçamentária discriminará em unidades orçamentárias específicas as dotações destinadas: 
+I – A Fundos Especiais; 
+II – Às ações de Saúde e Assistência Social; 
+III – Ao Regime Próprio de Previdência Social; 
+IV – À manutenção e Desenvolvimento do Ensino. 
+Art. 16º - O Município não gastará menos que 25% (vinte e cinco por cento) no Desenvolvimento do Ensino, nem menos que 15% (quinze por cento) nas ações de saúde, em relação às receitas resultantes de imposto 
+e transferências constitucionais, conforme determina o artigo 212 da Constituição Federal e Lei Complementar 141, respectivamente, devendo a Lei Orçamentária para 2023 já fixar tais valores mínimos. 
+Art. 17º - A Lei do Orçamento Anual poderá conter autorização para abertura de créditos suplementares e contratação de operações de crédito em conformidade com os limites e condições fixados pelo Senado 
+Federal e nos termos da Lei Complementar Federal nº 101, de 2000. 
+Art. 18 - Não poderão ser fixadas despesas, a qualquer título, sem prévia definição das respectivas fontes de recursos. 
+Art. 19 - Constará da Lei Orçamentária recurso para pagamento de sentenças judiciárias, consoante determina o Art. 100 da Constituição Federal. 
+Art. 20 - Fica autorizado o Poder Executivo a criar fontes de recurso, elementos, e ou subelementos de despesas dentro das ações pré-existentes visando a segregação das naturezas de despesas para controle de custos 
+e para a correta classificação destas. 
+Parágrafo Único – Quando a criação for de subelementos, este poderá ser dotado com parte dos créditos orçamentários de sua respectiva conta sintética sem onerar o limite de créditos adicionais. 
+Art. 21 - O Projeto de Lei Orçamentária que o Poder Executivo encaminhará ao Poder Legislativo será constituído de: 
+I – Texto da Lei; 
+II – Quadros Orçamentários Consolidados; 
+III – Anexo dos Orçamentos Fiscal e da Seguridade Social, discriminando a Receita e Despesa na forma definida nesta Lei; 
+IV – Discriminação na Legislação da Receita e da Despesa, referente aos Orçamentos Fiscal e da Seguridade Social; 
+V – Demonstrativo da renúncia da Receita e da margem de expansão das despesas obrigatórias de caráter continuado. 
+Art. 22 – Para efeito do disposto neste capítulo, O Poder Legislativo do Município e as entidades da Administração Pública Indireta encaminharão, ao Poder Executivo, até 31 de julho de 2022, sua respectiva 
+proposta orçamentária, para, se compatível com as determinações previstas na Constituição ou em lei infraconstitucional, serem incluídas no Projeto de Lei Orçamentária, observadas também as disposições desta Lei. 
+Art. 23 - A execução orçamentária dos Poderes poderá ser realizada através de descentralização de créditos orçamentários entre unidades gestoras, quando for efetuada movimentação de parte do orçamento, 
+mantidas as classificações institucional, funcional, programática e econômica, para que outras unidades administrativas possam executar a despesa orçamentária, sendo: 
+I – Descentralização interna de crédito ou provisão, envolvendo a transferência de créditos entre unidades gestoras de um mesmo órgão ou entidade; e 
+II – Descentralização externa de crédito ou destaque, envolvendo a transferência de créditos entre unidades gestoras de órgãos ou entidades de estruturas administrativas diferentes, de um órgão para outro e 
+dependerá, quando necessário, de celebração de convênio ou instrumento congênere. 
+§ 1º As descentralizações de créditos orçamentários não se confundem com remanejamentos, transferências e transposições, pois, não: 
+I – Modificam o valor da programação ou de suas dotações orçamentárias; 
+II – Alteram a unidade orçamentária (classificação institucional) detentora do crédito orçamentário aprovado na lei orçamentária ou em créditos adicionais. 
+Seção II 
+Do Equilíbrio Entre Receitas e Despesas 
+  
+Art. 24 - A Lei Orçamentária conterá reserva de contingência constituída de dotação global e corresponderá, na Lei Orçamentária, a 1% (um por cento) da receita corrente líquida prevista para o município e se 
+destinará a atender a passivos contingentes e eventos fiscais imprevistos. 
+Art. 25 - A compensação de que trata o Art. 17, §2º da Lei Complementar nº 101, de 2000, quando da criação ou aumento de despesas obrigatórias de caráter continuado, no âmbito dos Poderes Executivo, 
+Legislativo e Administrações Indiretas, poderá ser realizada a partir do aproveitamento de respectiva margem de expansão. 
+Parágrafo Único – Na hipótese de ocorrer as circunstâncias estabelecidas no caput do Art.9º, ou no inciso II, § 1º, do Art. 31, todos da Lei Complementar nº 101/2000, os Poderes Executivo e Legislativo deverão 
+proceder a respectiva limitação de empenho, no montante e prazo previstos nos respectivos artigos. 
+Art. 26 – O Poder Executivo poderá, durante o exercício de 2023, ajustar as fontes de recursos sem alterar a programação constante da Lei Orçamentária Anual para manter o equilíbrio na execução desta Lei. 
+Seção III 
+Dos Recursos Correspondentes às Dotações Orçamentárias e dos Créditos Adicionais Destinados ao Poder Legislativo 
+
+  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     32 
+ 
+
+Art. 27º - O Poder Legislativo do Município terá como limite de despesas em 2023, para efeito de elaboração de sua respectiva proposta orçamentária, a aplicação do percentual de até 7% (sete por cento) sobre o 
+somatório da receita tributária e das transferências, acrescido dos valores devidos aos inativos e pensionistas. 
+§ 1º Após finalização da arrecadação do exercício anterior, comprovada pela emissão do Balanço Geral, havendo diferença do resultado da aplicação do percentual, conforme caput deste artigo, em confronto com os 
+créditos autorizados para o Legislativo na LOA 2023, a diferença positiva deverá ser anulada no Executivo e suplementada no Legislativo. Sendo negativa a diferença, deverá ser anulada no Legislativo e 
+suplementada no Executivo. 
+§ 2º As dotações que porventura vierem a ser suplementadas e anuladas em obediência ao caput deste artigo, ficam a critério do respectivo Poder. 
+§ 3º Do período entre janeiro de 2023 até a publicação do Balanço geral do exercício de 2022, o duodécimo da Câmara de Vereadores corresponderá a 1/12 (um doze avos) do total de créditos autorizados para o 
+Poder Legislativo na LOA 2023 com respeito as disposições do Inciso III, parágrafo 2º do Art. 29A da Constituição Federal de 1988. 
+Art. 28º - O repasse financeiro relativo aos créditos orçamentários e adicionais será feito diretamente em conta bancária indicada pelo Poder Legislativo. 
+Parágrafo Único – Ao final do exercício financeiro, o superávit financeiro dos recursos do Legislativo será devolvido ao Poder Executivo. 
+Art. 29º - A execução orçamentária do Legislativo será independente, mas integrada ao Executivo para fins de consolidação contábil. 
+Seção IV 
+Da Disposição Sobre Novos Projetos 
+  
+Art. 30º - Além da observância das prioridades e metas de que trata esta Lei, a Lei Orçamentária e seus créditos adicionais, somente incluirão projetos novos após: 
+I – Tiverem sido adequadamente contemplados todos os projetos em andamento; 
+II – Estiverem assegurados os recursos de manutenção do patrimônio público. 
+§ 1º - Não constitui infração a este artigo o início de novo projeto, mesmo possuindo outros projetos em andamento, caso haja suficiente previsão de recursos orçamentários, e que seja custeado por outra esfera de 
+Governo. 
+§ 2º - Fica o Poder Executivo autorizado a destinar recursos na Lei Orçamentária de 2023 prioritariamente para conclusão de obras de reparo, compras de equipamentos ou de construção de unidades públicas de 
+saúde, com o objetivo de destiná-los ao atendimento de pacientes infectados pela Covid-19. 
+Seção V 
+Da Transferência de Recursos Para as Entidades da Administração Indireta 
+  
+Art. 31º - O Município poderá efetuar transferências financeiras intragovernamentais autorizadas em Lei específica, conforme preconiza a Constituição da República, Art. 167, a entidades da administração indireta 
+até os limites necessários à manutenção das entidades ou investimentos previstos e que não haja suficiente disponibilidade financeira. 
+Seção VI 
+Das Transferências de Recursos Para o Setor Privado 
+
+  
+Art. 32º - É vedada a inclusão, na Lei Orçamentária e em seus créditos adicionais, de dotações a título de subvenções sociais ou auxílios, ressalvadas aquelas destinadas a entidades privadas sem fins lucrativos, de 
+atividades de natureza continuada, que preencham uma das seguintes condições: 
+I – Sejam atendimento direto ao público, de forma gratuita, nas áreas de assistência social, saúde, educação, cultura ou desporto, e estejam registradas nas Secretarias Municipais correspondentes: 
+II – Sejam vinculadas a organismos de natureza filantrópica, institucional ou assistencial; 
+III – Atendam ao disposto no Art. 204 da Constituição da República, no art. 61 do ADCT, bem como na Lei no 8.742, de 07 de dezembro de 1993. 
+Parágrafo Único – Para habilitar-se ao recebimento de subvenções sociais, a entidade privada sem fins lucrativos deverá apresentar declaração de funcionamento regular nos últimos dos anos, contendo: 
+a) Certidão Negativa junto ao INSS; 
+b) Certidão Negativa junto à Receita Federal; 
+c) Certidão Negativa junto à Fazenda Pública Estadual; 
+d) Certidão Negativa junto à Fazenda Pública Municipal; 
+e) Certidão Negativa junto ao FGTS. 
+Seção VII 
+Das Transferências às Pessoas Físicas e Jurídicas 
+  
+Art. 33º - Fica o Poder Executivo Municipal autorizado a atender necessidades de pessoas físicas, através dos programas instituídos de assistência social. 
+Parágrafo Único – A transferência de recursos dependerá de parecer prévio da Secretaria Municipal de Assistência Social, ou órgão equivalente do município, que analisará os casos individualmente, aprovando-os 
+ou não. 
+Art. 34º - A transferência de recursos públicos para cobrir necessidades de pessoas jurídicas sem fins lucrativos deverá ser autorizada na Lei Orçamentária Anual ou por Lei específica para atender a entidade que 
+abranja atividades nas áreas de assistência social, saúde, agricultura, desporto, turismo ou educação. § 1º - A transferência de recursos dependerá de parecer prévio da Secretaria Municipal a qual a entidade privada 
+seja relacionada, de acordo com a atividade executada. 
+§ 2º - A transferência de recursos dependerá da apresentação de declaração de funcionamento regular nos últimos dois anos, contendo: 
+a) Certidão Negativa junto ao INSS; 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     33 
+ 
+
+b) Certidão Negativa junto à Receita Federal; 
+c) Certidão Negativa junto à Fazenda Pública Estadual; 
+d) Certidão Negativa junto à Fazenda Pública Municipal; 
+e) Certidão Negativa junto ao FGTS. 
+CAPÍTULO V 
+DAS DIRETRIZES PARA EXECUÇÃO DOS ORÇAMENTOS 
+Seção I 
+Dos Créditos Adicionais 
+  
+Art. 35 - A Lei Orçamentária, autorizará a abertura de créditos adicionais, do tipo suplementar com percentual de 60% (sessenta por cento) da receita prevista para o exercício de 2023. 
+Art. 36 - Os créditos adicionais especiais e extraordinários, se abertos nos últimos quatro meses do exercício de 2022, poderão ser reabertos, pelos seus saldos, no exercício de 2023 por Decreto do Poder Executivo. 
+Art. 37 - Fica o Poder Executivo, mediante Decreto, autorizado a efetuar transposição, remanejamento e transferências de dotações orçamentárias. 
+§ 1º - A transposição, remanejamento e transferência são instrumentos de flexibilização orçamentária, diferenciando-se dos créditos adicionais que tem a função de corrigir desvios de planejamento. 
+§ 2º - Para efeitos das Leis Orçamentárias, entende-se por: 
+I – Transposição: o deslocamento de excedentes de dotações orçamentárias de categorias de programação totalmente concluídas no exercício para outras incluídas como prioridade no exercício. 
+II – Remanejamento – deslocamento de créditos e dotações relativos à extinção, desdobramento ou incorporação de unidades orçamentárias à nova unidade; 
+III – Transferência – deslocamento permitido de dotações de um mesmo programa de Governo. 
+CAPÍTULO VI 
+DAS DIRETRIZES SOBRE ALTERAÇÕES NA LEGISLAÇÃO TRIBUTÁRIA 
+
+  
+Art. 38 - As receitas serão estimadas e discriminadas de duas formas: 
+I - Considerando a legislação tributária vigente até a data do envio do Projeto de Lei Orçamentária à Câmara Municipal; e 
+II - Considerando, se for o caso, os efeitos das alterações na legislação tributária, resultantes de Projetos de Lei encaminhados à Câmara Municipal até três meses antes do encerramento do exercício de 2022, 
+especialmente sobre: 
+a) reavaliação das alíquotas dos tributos; 
+b) critérios de atualização monetária; 
+c) aperfeiçoamento dos critérios para correção dos créditos do Município recebidos com atraso; 
+d) alteração nos prazos de apuração, arrecadação e recolhimento dos tributos; 
+e) extinção, redução e instituição de isenções de incentivos fiscais; 
+f) revisão das contribuições sociais, destinadas à seguridade social; 
+g) revisão da legislação sobre taxas; e 
+h) concessão de anistia e remissões tributárias. 
+Art. 39 - Caso não sejam aprovadas as modificações referidas no inciso II do art. 38 ou essas o sejam parcialmente, de forma a impedir a integralização dos recursos estimados, o Poder Executivo providenciará os 
+ajustes necessários, mediante decretos, na hipótese de previsão de despesa na Lei Orçamentária Anual. 
+Parágrafo único - Os decretos referidos no caput deste artigo deverão informar o impacto dos ajustes necessários sobre as metas e prioridades da Administração. 
+Art. 40 - Na aplicação de lei que conceder ou ampliar incentivo, isenção ou benefício de natureza tributária ou financeira dever-se-á observar a devida anulação de despesas em valor equivalente caso produza 
+impacto financeiro no mesmo exercício, respeitadas as disposições do art. 14 da Lei Complementar nº 101, de 2000. 
+CAPÍTULO VII 
+DAS DISPOSIÇÕES RELATIVAS ÀS DESPESAS COM PESSOAL 
+  
+Art. 41 - No Projeto de Lei Orçamentária para o exercício financeiro de 2023, as despesas com Pessoal e Encargos não poderão ultrapassar o limite estabelecido nos artigos 19 e 20 da Lei Complementar 101/2000. 
+Parágrafo Único – Caso o município, quando da elaboração da Lei Orçamentária para 2023 já esteja acima do limite previsto no art. 19 e 20 da Lei Complementar 101/2000, as vedações contidas no referido artigo 
+deverão ser observadas quando da fixação destes gastos. 
+Art. 42 - No Exercício de 2023, caso a despesa total com pessoal exceder o limite previsto no parágrafo único do Art. 22 da Lei Complementar 101 de 2000, a realização de serviço extraordinário em qualquer dos 
+Poderes somente poderá ocorrer no caso previsto no art. 57, § 6º, inciso II, da Constituição, ou quando destinada ao atendimento de relevantes interesses públicos que ensejam situações emergenciais, de risco ou 
+prejuízo para a sociedade, dentre estes: 
+I – Situações de emergência e calamidade pública; 
+II – Situações em que possam estar em risco a segurança de pessoas ou bens; 
+III – A relação custo-benefício se revelar favorável em relação à alternativa possível. 
+Art. 43 - A Lei Orçamentária para o exercício financeiro de 2023 não poderá fixar o total das Despesas com Pessoal e Encargos acima do limite previsto na letra “b”, inciso III do Art. 20 da Lei Complementar 101 
+de 2000, devendo este limite ser observado por cada Poder, separadamente. 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     34 
+ 
+
+Art. 44 - Ficam autorizados os Poderes Executivo e Legislativo, a realizar concurso público no exercício de 2023 para reposição do quadro de pessoal das áreas consideradas prioritárias para a Administração Pública 
+Municipal. 
+Art. 45 - Quando a despesa de pessoal ultrapassar o limite prudencial estabelecido na Lei Complementar Federal nº 101, de 2000, a realização de serviço extraordinário, no decorrer do exercício de 2023, dependerá 
+de autorização especial prévia do Prefeito e será admitida apenas para setores considerados relevantes para o interesse público, voltados para as áreas de segurança, educação e de saúde, em situações de emergências 
+que envolvam risco ou prejuízo para a população. 
+Art. 46 - Para fins de atendimento ao disposto no art. 169 §1º, inciso II, da Constituição da República, ficam autorizados, além das vantagens pessoais já previstas nos planos de cargos e regime jurídico: 
+I – Concessão e aumento de remuneração, através de reajuste/alteração, inclusive como forma de revisão geral anual; 
+II – Criação de cargos, empregos e funções de confiança, observadas as necessidades da Administração Pública; 
+III – Reforma do plano de cargos e carreiras do magistério público municipal; 
+IV – Reforma do plano de cargos e carreiras do Legislativo Municipal; 
+V – Admissão de pessoal por aprovação em concurso público para cargo ou emprego público, com disponibilidade de vagas; 
+VI – Designação de função de confiança ou cargo em comissão, com disponibilidade de vagas; 
+VII – Concessão de abono remuneratório aos servidores em exercício de cargo em comissão ou função de confiança; 
+VIII – Contratação de pessoal por tempo determinado, nos casos de excepcional interesse público, desde que atendidos os pressupostos que caracterizem como tal, nos termos da Lei Municipal específica, e que 
+venham a atender a situações cuja investidura por concurso não se revele a mais adequada, face às características da necessidade da contratação. 
+§ 1º - O atendimento ao disposto neste artigo deverá ser observado pelos Poderes Executivo e Legislativo; 
+§ 2º - Lei específica deverá ser editada quando da implantação dos incisos II, III e IV; 
+§ 3º - No caso de implantação do inciso I deste artigo, lei específica deverá ser editada definindo o índice e o mês da revisão, observando-se sempre os limites mínimos e máximos para salários, além dos limites das 
+despesas com pessoal previstos no inciso III, art. 20 e vedações do parágrafo único, inciso I do art. 22, todos da Lei Complementar nº 101 de 2000; 
+§ 4º - Nos casos dos incisos deste artigo, deverá sempre ser observado o que preconizam os Arts. 16, 17, 19, 20, 21, 22 e 23 da Lei Complementar nº 101 de 2000, quando de sua implantação. 
+  
+CAPÍTULO VIII 
+DO NÃO – ATINGIMENTO DAS METAS FISCAIS 
+
+  
+Art. 47 - A limitação de empenho prevista nesta Lei, deverá seguir a seguinte ordem de limitação: 
+I – No Poder Executivo: 
+a) Diárias; 
+b) Serviço extraordinário; 
+c) Aquisição de material de consumo; 
+d) Realização de obras com recursos próprios. 
+II – No Poder Legislativo: 
+a) Diárias; 
+b) Serviço extraordinário; 
+c) Aquisição de material de consumo; 
+d) Realização de obras com recursos próprios. 
+§ 1º - As limitações previstas no inciso I deste artigo não podem abranger os projetos e atividades cujo despesa constitui obrigação constitucional ou legal de execução; 
+§ 2º - Em não sendo suficiente, ou inviável sob o ponto de vista da administração, a limitação de empenho poderá ocorrer sobre outras despesas, com exceção: 
+I – Das despesas com pessoal e encargos sociais; 
+II – Das despesas necessárias para o atendimento à saúde, bem como das despesas voltadas para a manutenção do ensino; 
+III – Das despesas necessárias para o atendimento à Assistência Social; 
+IV – Das despesas com o pagamento de precatórios judiciais; 
+V – Das despesas com o pagamento dos encargos e do principal da dívida consolidada do município; 
+§ 3º - A limitação de empenho corresponderá, em termos percentuais, ao valor ultrapassado da meta de resultado primário ou nominal, estabelecido no Anexo de Metas Fiscais. 
+Art. 48 - O Poder Executivo, por intermédio da Controladoria Geral do Município implementará normas de acompanhamento das ações governamentais visando o controle de custos e a avaliação dos resultados dos 
+programas financiados com recursos do orçamento. 
+Parágrafo Único – Os métodos e processos de controle de custos serão praticados em todos os órgãos da Administração Municipal, de acordo com as disciplinas legais vigentes. 
+CAPÍTULO IX 
+DO REGIME PRÓPRIO DE PREVIDÊNCIA SOCIAL – RPPS 
+
+  
+Art. 49 - O Orçamento do Regime Próprio de Previdência Social do Município, será elaborado obedecendo-se os ditames das normas, regulamentos e procedimentos dispostos na legislação previdenciária vigente, 
+nos termos preconizado pela Secretaria Especial de Previdência e Trabalho, Secretaria do Tesouro Nacional e pelo Tribunal de Contas. 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     35 
+ 
+
+Art. 50 - O Cálculo Atuarial previsto nesta Lei deverá ser avaliado e comparado, a partir da legislação do RPPS, a fim de que se preservem o equilíbrio financeiro e atuarial do regime de previdência. 
+CAPÍTULO X 
+DAS DISPOSIÇÕES RELATIVAS À DÍVIDA PÚBLICA MUNICIPAL 
+  
+Art. 51 - A Lei Orçamentária anual garantirá recursos para pagamento da despesa com a dívida contratual e com o refinanciamento da dívida pública Municipal, nos termos dos contratos firmados. 
+Art. 52 - Se a dívida consolidada líquida do Município ultrapassar o limite legal estabelecido, deverá ser a ele reconduzido nos termos da legislação vigente. 
+Parágrafo Único. Enquanto perdurar o excesso, o Município obterá resultado primário necessário à recondução da dívida ao limite, promovendo, entre outras medidas, limitação de empenho, na forma da presente 
+lei. 
+CAPÍTULO XI 
+DA TRANSPARÊNCIA DA GESTÃO FISCAL 
+
+  
+Art. 53 - O Poder Executivo, para fins de transparência da gestão fiscal e em observância ao princípio da publicidade, tornará disponíveis na internet, para acesso de toda sociedade, no mínimo, as seguintes 
+informações: 
+I - Os Planos, Orçamentos e Lei de Diretrizes Orçamentárias; 
+II - As Prestações de Contas e respectivos Pareceres Prévios; 
+III - O Relatório Resumido da Execução Orçamentária; 
+IV - O Relatório de Gestão Fiscal; 
+V – As Demonstrações Contábeis Aplicadas ao Setor Público. 
+CAPÍTULO XII 
+DAS DISPOSIÇÕES FINAIS 
+  
+Art. 54 - Para fins de cumprimento do Art. 62 da Lei Complementar 101 de 2000, fica o Município autorizado a firmar convênio ou acordo com a União ou Estados, com vistas: 
+I – Ao funcionamento de serviços bancários e de segurança pública; 
+II – A possibilitar o assessoramento técnico aos produtores rurais do município; 
+III – À utilização conjunta, no Município, de máquinas e equipamentos de propriedade do Estado ou União; 
+IV – A cessão de servidores para o funcionamento de órgãos ou entidades no Município; 
+V – A realização de obras e serviços públicos de interesse público local. 
+Art. 55 - Considera-se despesa irrelevante para fins do disposto no parágrafo 3º do artigo 16 da Lei Complementar no 101, de 04 de maio de 2000, a despesa cujo valor não ultrapasse, para bens e serviços, o limite 
+estabelecido no artigo 24, incisos I e II da Lei no 8.666, de 21 de junho de 1993 e alterações posteriores. 
+Art. 56 - As emendas ao projeto de Lei Orçamentária para 2023, ou aos projetos de lei que modifiquem a Lei de Orçamento Anual, devem atender às seguintes condições: 
+§ 1º Serem compatíveis com os programas e objetivos do Plano Plurianual para o quadriênio de 2022/2025 e com as diretrizes, disposições, prioridades e metas desta Lei. 
+§ 2º Indicarem os recursos necessários, admitidos apenas os provenientes de anulação de despesa. 
+I - Não serão admitidas anulações de despesa que incidam sobre dotações para: 
+a) pessoal e encargos sociais; e 
+b) serviço da dívida. 
+Art. 57. As emendas ao projeto de lei de orçamento anual deverão considerar, ainda, a prioridade das dotações destinadas ao pagamento de precatórios judiciais e outras despesas obrigatórias, assim entendidas 
+aquelas com legislação ou norma específica; despesas financiadas com recursos vinculados e recursos para compor a contrapartida Municipal de empréstimos internos e externos. 
+Art. 58 - Sem prejuízo das competências constitucionais e legais do Poder Legislativo e dos órgãos da Administração Público Municipal, as unidades responsáveis pelos seus orçamentos ficam sujeitas às orientações 
+normativas que vierem a ser adotadas pelo Poder Executivo. 
+Art. 59 - Se o Projeto de Lei Orçamentária não for devolvido para a sansão do Poder Executivo até o final da última sessão do Legislativo do Exercício de 2022, ficarão os Poderes autorizados a utilizar 1/12 (um 
+doze avos) do orçamento previsto para 2023, até que o Executivo receba a Lei aprovada, e proceda sua sanção e publicação. 
+Art. 60 - Em razão de eventuais descontinuidades de política econômica, o Poder Executivo poderá enviar mensagem reavaliando os parâmetros relativos às metas fiscais até o prazo de que tratam o § 5º do art. 166 
+da Constituição Federal. 
+Art. 61º. Esta Lei entra em vigor na data de sua publicação. 
+  
+Dê-se Ciência, Publique-se, Registre-se e Cumpra-se. 
+  
+GABINETE DO PREFEITO MUNICIPAL DE MARAGOGI, Estado de Alagoas, aos 30 (trinta) dias do mês de junho de 2022. 
+  
+FERNANDO SÉRGIO LIRA NETO 
+Prefeito do Município de Maragogi, Estado de Alagoas  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     36 
+ 
+
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE RISCOS FISCAIS 
+DEMONSTRATIVO DE RISCOS FISCAIS E PROVIDÊNCIAS 
+  
+ARF (LRF, art. 4º, § 3º) R$ 1,00 
+  
+
+PASSIVOS CONTIGENTES PROVIDÊNCIAS 
+
+Descrição Valor Descrição Valor 
+
+Demandas Judiciais       
+
+Dívidas em Processo de Reconhecimento 10.000.000,00 Abertura de créditos adicionais a partir da anulação de despesas discricionárias 10.000.000,00 
+
+Avais e Garantias Concedidas       
+
+Assunção de Passivos de RPPS 2.400.000,00 Abertura de créditos adicionais a partir da anulação de despesas discricionárias 2.400.000,00 
+
+Assistência a epidemias 2.000.000,00 Abertura de créditos adicionais a partir da Reserva de Contingência 2.000.000,00 
+
+Outros Passivos Contingentes       
+
+SUBTOTAL 14.400.000,00 SUBTOTAL 14.400.000,00 
+
+  
+DEMAIS RISCOS FISCAIS PASSIVOS PROVIDÊNCIAS 
+
+Descrição Valor Descrição Valor 
+
+Frustrações de Arrecadação 3.424.362,00 Adequação da despesa pela redução e limitação de gastos, respeitando a fonte de recurso de origem 3.424.362,00 
+
+Restituição de Tributos a Maior       
+
+Discrepância de Projeções       
+
+Outros Riscos Fiscais       
+
+SUBTOTAL 3.424.362,00 SUBTOTAL 3.424.362,00 
+
+TOTAL 17.824.362,00 TOTAL 17.824.362,00 
+
+  
+Fonte: TC Contabilidade Público, SEFAZ, 27/mar/2022, 15h e 00m 
+  
+LEI DE DIRETRIZES ORÇAMENTÁRIAS 
+ANEXO DE METAS FISCAIS 
+METAS ANUAIS 
+2023 
+  
+AMF – Demonstrativo 1 (LRF, art 4ºm § 1º) R$ 1,00 
+  
+
+  
+ESPECIFICAÇÃO 
+
+2023 2024 2025 
+
+Valor 
+Corrente 
+
+(a) 
+
+Valor 
+Constante 
+
+% PIB 
+(a/PIB) 
+X100 
+
+%RCL 
+(a/RCL) 
+
+X 100 
+
+Valor 
+Corrente 
+
+(b) 
+
+Valor 
+Constante 
+
+% PIB 
+(b/PIB) 
+X100 
+
+%RCL 
+(b/RCL) 
+
+X 100 
+
+Valor 
+Corrente 
+
+(c) 
+
+Valor 
+Constante 
+
+% PIB 
+(c/PIB) 
+X100 
+
+%RCL 
+(c/RCL) 
+X 100 
+
+Receita Total 171.548.450,70 165.347.904,29 0,278% 116,22% 172.263.699,39 160.979.066,81 0,274% 113,14% 177.341.610,40 160.883.253,56 0,276% 113,08% 
+
+Receitas Primárias 157.923.817,91 152.215.728,11 0,256% 1,07 158.470.594,45 148.089.519,16 0,252% 1,04 163.224.712,32 148.076.487,63 0,254% 1,04 
+
+Receitas Primárias Correntes 147.628.995,50 142.293.007,71 0,239% 1,00 151.709.828,74 141.771.636,99 0,241% 1,00 156.261.123,63 141.759.161,42 0,243% 1,00 
+
+Impostos, Taxas e Contribuições de Melhoria 26.401.209,16 25.446.948,59 0,043% 17,89% 27.232.847,25 25.448.880,71 0,043% 17,89% 28.049.832,66 25.446.641,26 0,044% 17,89% 
+
+Contribuições 8.835.965,98 8.516.593,72 0,014% 5,99% 9.123.037,24 8.525.406,26 0,014% 5,99% 9.396.728,36 8.524.656,05 0,015% 5,99% 
+
+Transferências Correntes 112.391.820,36 108.329.465,41 0,182% 76,14% 115.353.944,25 107.797.350,01 0,183% 75,76% 118.814.562,61 107.787.864,11 0,185% 75,76% 
+
+Demais Receitas Primárias Correntes 0,00 0,00 0,000% 0,00% 0,00 0,00 0,000% 0,00% 0,00 0,00 0,000% 0,00% 
+
+Receitas Primárias de Capital 10.294.822,41 9.922.720,40 0,017% 6,97% 6.760.765,71 6.317.882,17 0,011% 4,44% 6.963.588,69 6.317.326,22 0,011% 4,44% 
+
+Despesa Total 173.232.187,47 166.970.783,10 0,281% 117,36% 173.878.127,70 162.487.737,31 0,276% 114,20% 178.960.263,96 162.351.686,44 0,279% 114,11% 
+
+Despesas Primárias (II) 157.567.104,36 151.871.907,82 0,255% 1,07 159.338.337,19 148.900.417,90 0,253% 1,05 161.984.279,75 146.951.174,59 0,252% 1,03 
+
+Despesas Primárias Correntes 138.038.004,32 133.048.678,86 0,244% 0,94 144.228.600,81 134.780.488,56 0,229% 0,95 148.555.458,83 134.768.628,17 0,231% 0,95 
+
+Pessoal e Encargos Sociais 79.305.493,26 76.439.029,65 0,129% 53,73% 83.424.089,59 77.959.152,97 0,133% 54,79% 85.926.812,28 77.952.292,73 0,134% 54,79% 
+
+Outras Despesas Correntes 58.732.511,06 56.609.649,21 0,095% 39,79% 60.804.511,22 56.821.335,59 0,097% 39,94% 62.628.646,55 56.816.335,43 0,098% 39,94% 
+
+Despesas Primárias de Capital 17.845.363,27 17.200.350,14 0,029% 12,09% 13.495.308,07 12.611.258,83 0,021% 8,86% 11.810.167,36 10.714.113,54 0,018% 7,53% 
+
+Pagamento de Restos a Pagar de Despesas Primárias 1.683.736,77 1.622.878,81 0,003% 1,14% 1.614.428,31 1.508.670,51 0,003% 1,06% 1.618.653,56 1.468.432,88 0,003% 1,03% 
+
+Resultado Primário (III) = (I-II) 356.713,55 343.820,29 0,001% 0,00 -867.742,74 -810.898,74 -0,001% -0,01 1.240.432,57 1.125.313,05 0,002% 0,01 
+
+Juros, Encargos e Variações Monetárias Ativos (IV) 0,00 0,00 0,000% 0,00% 0,00 0,00 0,000% 0,00% 0,00 0,00 0,000% 0,00% 
+
+Juros, Encargos e Variações Monetárias Passivos (V) 254.171,76 244.640,32 0,000% 0,00% 262.178,17 245.003,43 0,000% 0,00% 270.043,52 244.981,87 0,000% 0,00% 
+
+Resultado Nominal - (VI) = (III + (IV – V)) 102.541,79 99.179,97 0,001% 0,00 -1.129.920,91 -1.055.902,17 -0,001% -0,01 970.389,05 880.331,17 0,002% 0,01 
+
+Dívida Pública Consolidada 7.054.125,93 6.799.157,52 0,011% 4,78% 6.376.929,84 5.959.190,58 0,010% 4,19% 5.764.744,58 5.229.741,97 0,009% 3,68% 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     37 
+ 
+
+Dívida Consolidada Liquida -48.985.338,60 -47.214.784,19 -0,079% -33,19% -53.829.945,25 -50.303.658,77 -0,086% -35,35% -53.521.872,62 -48.554.724,32 -0,083% -34,13% 
+
+Receitas Primárias advindas de PPP (VII) 0,00 0,00 0,00% 0,00% 0,00 0,00 0,00 0,00% 0,00 0,00 0,00% 0,00% 
+
+Despesas Primárias geradas por PPP (VIII) 0,00 0,00 0,00% 0,00% 0,00 0,00 0,00 0,00% 0,00 0,00 0,00% 0,00% 
+
+Impacto do saldo das PPPs (IX) = (VII – VIII) 0,00 0,00 0,00% 0,00% 0,00 0,00 0,00 0,00% 0,00 0,00 0,00% 0,00% 
+
+  
+Fonte: TC Contabilidade Pública, Divisão de Contabilidade/SMf, 26/mar/2022, 18h e 05m 
+Nota: O cálculo das meta foi realizado considerando-se o seguinte cenário macroeconômico Índice Nacional de Preços ao Consumidor Amplo – IPCA Acumulado, estimado com base nos indicativos do Banco 
+Central do Brasil, Produto Interno Bruto PIB, estimado de acordo com projeção do Banco Central do Brasil para o Estado. 
+  
+
+VARIÁVEIS 2023 2024 2025 
+
+PIB real (crescimento % anual) 1,30 2,00 2,00 
+
+Taxa real de juro implícito sobre a dívida liquida do Governo 9,00 7,50 7,00 
+
+Câmbio (RS/USS – Final do ano) 5,22 5,20 5,20 
+
+Inflação média (% anual) projetada com base no índice oficial 3,75 3,15 3,00 
+
+Projeção do PIB do Estado - R$ milhares 61.689.412.520 62.923.200.770 64.181.664.785 
+
+Receita Corrente Líquida - RCL 147.607,791 152.257.436 156.825.159 
+
+  
+FONTE: Boletim Focus, BCB, 27/mar/2022, 15h e 05m 
+  
+L.D.O. 2023 
+Metodologia de calculo – Receitas por Categoria Econômica 
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.0.0.0.00.00.00.00.0000 Receitas Correntes 137.263.420,06 111.849.280,58 146.069.148,96 126.223.041,45 151.703.956,29 156.320.464,43 161.010.078,37 165.840.380,73 
+
+1.1.0.0.00.00.00.00.0000 Impostos, Taxas e Contribuições de Melhorias 18.018.884,16 16.234.703,50 25.446.948,60 18.704.375,83 26.401.209,16 27.232.847,25 28.049.832,66 28.891.327,65 
+
+1.1.1.0.00.00.00.00.0000 Impostos 15.646.716,15 15.090.506,18 22.764.088,54 16.823.840,50 23.617.741,86 24.361.700,73 25.092.551,75 25.845.328,31 
+
+1.1.1.2.00.00.00.00.0000 Impostos sobre o Patrimônio 4.568.607,99 4.322.602,71 9.457.677,77 4.167.208,18 9.812.340,68 10.121.429,42 10.425.072,30 10.737.824,47 
+
+1.1.1.2.50.00.00.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana 3.690.556,25 3.180.177,06 8.344.866,99 3.303.156,53 8.657.799,50 8.930.520,19 9,198.435,79 9.474.388,86 
+
+1.1.1.2.50.01.00.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana 3.690.556,25 3.180.177,06 8.344.866,99 3.303.156,53 8.657.799,50 8.930.520,19 9,198.435,79 9.474.388,86 
+
+1.1.1.2.50.01.01.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana – Principal 3.505.965,21 3.180.177,06 7.201.032,33 3.260.685,99 7.471.071,04 7.706.409,76 7.937.602,07 8.175.730,13 
+
+1.1.1.2.50.01.02.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana – Juros e Multa 116.049,81 0,00 1.143.834,66 0,00 1.186.728,46 1.224.110,41 1.260.833,72 1.298.658,73 
+
+1.1.1.2.50.01.03.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana – Dívida Ativa 10.053,06 0,00 0,00 42.470,54 0,00 0,00 0,00 0,00 
+
+1.1.1.2.50.01.04.00.0000 Imposto sobre a Propriedade Predial e Territorial Urbana – Dívida Ativa multa e juros 58.488,17 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.1.1.2.53.00.00.00.0000 Imposto sobre Transmissão (Inter Vivos) de Bens Imóveis e de Direitos Reais Sobre Imóveis 878.051,74 1.142.425,65 1.112.810,78 864.051,65 1.154.541,18 1.190.909,23 1.226.636,51 1.263.435,61 
+
+1.1.1.2.53.01.00.00.0000 Imposto sobre Transmissão (Inter Vivos) de Bens Imóveis e de Direitos Reais Sobre Imóveis 878.051,74 1.142.425,65 1.112.810,78 864.051,65 1.154.541,18 1.190.909,23 1.226.636,51 1.263.435,61 
+
+1.1.1.2.53.01.01.00.0000 Imposto sobre Transmissão (Inter Vivos) de Bens Imóveis e de Direitos Reais Sobre Imóveis – Principal 878.051,74 1.142.425,65 1.112.810,78 864.051,65 1.154.541,18 1.190.909,23 1.226.636,51 1.263.435,61 
+
+1.1.1.3.00.00.00.00.0000 Imposto sobre a Renda e Proventos de Qualquer Natureza 1.540.033,67 2.507.136,91 2.350.230,88 2.520.817,08 2.438.364,54 2.515.173,02 2.590.628,21 2.590.628,21 
+
+1.1.1.3.03.00.00.00.0000 Imposto sobre Renda – Retido na Fonte 1.540.033,67 2.507.136,91 2.350.230,88 2.520.817,08 2.438.364,54 2.515.173,02 2.590.628,21 2.590.628,21 
+
+1.1.1.3.03.01.00.00.0000 Imposto sobre Renda – Retido na Fonte – Trabalho 1.540.033,67 2.507.136,91 2.350.230,88 2.520.817,08 2.438.364,54 2.515.173,02 2.590.628,21 2.590.628,21 
+
+1.1.1.3.03.01.01.00.0000 Imposto sobre Renda – Retido na Fonte – Trabalho – Principal 1.540.033,67 2.507.136,91 2.350.230,88 2.520.817,08 2.438.364,54 2.515.173,02 2.590.628,21 2.590.628,21 
+
+1.1.1.4.00.00.00.00.0000 Imposto sobre a Produção 9.538.074,49 8.260.766,56 10.956.179,89 10.135.815,24 11.367.036,64 11.725.098,29 12.076.851,24 12.439.156,78 
+
+1.1.1.4.51.00.00.00.0000 Impostos sobre Serviços 9.538.074,49 8.260.766,56 10.956.179,89 10.135.815,24 11.367.036,64 11.725.098,29 12.076.851,24 12.439.156,78 
+
+1.1.1.4.51.01.00.00.0000 Imposto sobre Serviços de Qualquer Natureza – ISSQN 9.538.074,49 8.260.766,56 10.956.179,89 10.135.815,24 11.367.036,64 11.725.098,29 12.076.851,24 12.439.156,78 
+
+1.1.1.4.51.01.01.00.0000 Imposto sobre Serviços de Qualquer Natureza – ISSQN – Principal 9.538.074,49 8.260.766,56 10.956.179,89 10.135.815,24 11.367.036,64 11.725.098,29 12.076.851,24 12.439.156,78 
+
+1.1.1.4.51.01.03.00.0000 Imposto sobre Serviços de Qualquer Natureza – ISSQN - Dívida Ativa 12.137,65 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.1.2.0.00.00.00.00.0000 Taxas 2.372.168,01 1.144.197,32 2.682.860,06 1.880.535,33 2.783.467,30 2.817.146,52 2.957.280,91 3.045.999,34 
+
+1.1.2.1.00.00.00.00.0000 Taxas pelo Exercício do Poder de Polícia 2.372.168,01 1.144.197,32 2.248.185,36 1.880.535,33 2.332.492,30 2.405.965,81 2.478.144,78 2.552.489,13 
+
+1.1.2.1.50.00.00.00.0000 Taxa de Fiscalização de Vigilância Sanitária 42.137,20 25.152,19 40.946,50 38.270,88 42.481,99 43.820,17 45.134,78 46.488,82 
+
+1.1.2.1.50.01.00.00.0000 Taxa de Fiscalização de Vigilância Sanitária 42.137,20 25.152,19 40.946,50 38.270,88 42.481,99 43.820,17 45.134,78 46.488,82 
+
+1.1.2.1.50.01.01.00.0000 Taxa de Fiscalização de Vigilância Sanitária – Principal 42.137,20 25.152,19 40.946,50 38.270,88 42.481,99 43.820,17 45.134,78 46.488,82 
+
+1.1.2.1.52.00.00.00.0000 Taxas de Inspeção, Controle e Fiscalização – Outras 2.330.030,81 1.119.045,13 2.207.238,86 1.842.264,45 2.290.010,31 2.362.145,64 2.433.010,00 2.506.000,31 
+
+1.1.2.1.52.01.00.00.0000 Taxa de Licença para Funcionamento de Estabelecimentos Comerciais, Indústrias e Prestadora de serviços 605.458,35 0,00 386.240,29 398.840,68 400.724,30 413.347,12 425.747,53 438.519,96 
+
+1.1.2.1.52.01.01.00.0000 Taxa de Licença para Funcionamento de Estabelecimentos Comerciais, Indústrias e Prestadora de serviços-Princ 605.458,35 0,00 386.240,29 398.840,68 400.724,30 413.347,12 425.747,53 438.519,96 
+
+1.1.2.1.52.02.00.00.0000 Taxa de Autorização de Funcionamento de Funcionamento de Transporte 109.220,75 0,00 59.680,05 69.400,04 61.918,05 63.868,47 65.784,52 67.758,06 
+
+1.1.2.1.52.02.01.00.0000 Taxa de Autorização de Funcionamento de Funcionamento de Transporte – Principal 109.220,75 0,00 59.680,05 69.400,04 61.918,05 63.868,47 65.784,52 67.758,06 
+
+1.1.2.1.52.03.00.00.0000 Taxa de Utilização de Área de Domínio Público 169.460,29 0,00 41.715,94 103.360,77 43.280,29 44.643,62 45.982,93 47.362,42 
+
+1.1.2.1.52.03.01.00.0000 Taxa de Utilização de Área de Domínio Público – Principal 169.460,29 0,00 41.715,94 103.360,77 43.280,29 44.643,62 45.982,93 47.362,42 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     38 
+ 
+
+1.1.2.1.52.04.00.00.0000 Taxa de Controle e Fiscalização Ambiental 1.325.054,58 882.754,67 1.542.321,11 1.187.656,89 1.600.158,15 1.650.563,13 1.700.080,02 1.751.082,42 
+
+1.1.2.1.52.04.01.00.0000 Taxa de Controle e Fiscalização Ambiental – Principal 1.325.054,58 882.754,67 1.542.321,11 1.187.656,89 1.600.158,15 1.650.563,13 1.700.080,02 1.751.082,42 
+
+1.1.2.1.52.05.00.00.0000 Taxa de Limpeza Pública 69.817,83 0,00 0,00 26.488,36 0,00 0,00 0,00 0,00 
+
+1.1.2.1.52.05.01.00.0000 Taxa de Limpeza Pública – Principal 69.817,83 0,00 0,00 26.488,36 0,00 0,00 0,00 0,00 
+
+1.1.2.1.52.06.00.00.0000 Taxa de Expediente 50.019,01 0,00 38.618,95 46.423,25 40.067,16 41.329,26 42.569,16 43.846,23 
+
+1.1.2.1.52.06.01.00.0000 Taxa de Expediente - Principal 50.019,01 0,00 38.618,95 46.423,25 40.067,16 41.329,26 42.569,16 43.846,23 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.1.2.1.52.07.00.00.0000 Outras Taxas pelo Exercício do Poder de Polícia 0,00 236.290,46 138.662,52 10.094,46 143.862,36 148.394,02 152.845,84 157.431,22 
+
+1.1.2.1.52.07.01.00.0000 Outras Taxas pelo Exercício do Poder de Polícia – Principal 0,00 236.290,46 138.662,52 10.094,46 143.862,36 148.394,02 152.845,84 157.431,22 
+
+1.1.2.2.00.00.00.00.0000 Taxas pela Prestação de Serviços 0,00 0,00 434.674,70 0,00 450.975,00 465.180,71 479.136,13 493.510,21 
+
+1.1.2.2.01.00.00.00.0000 Taxas pela Prestação de Serviços 0,00 0,00 434.674,70 0,00 450.975,00 465.180,71 479.136,13 493.510,21 
+
+1.1.2.2.01.01.00.00.0000 Taxas pela Prestação de Serviços 0,00 0,00 434.674,70 0,00 450.975,00 465.180,71 479.136,13 493.510,21 
+
+1.1.2.2.01.01.01.00.0000 Taxas pela Prestação de Serviços – Principal 0,00 0,00 434.674,70 0,00 450.975,00 465.180,71 479.136,13 493.510,21 
+
+1.1.2.2.01.01.01.90.0000 TAXA DE LIMPEZA PÚBLICA 0,00 0,00 434.674,70 0,00 450.975,00 465.180,71 479.136,13 493.510,21 
+
+1.2.0.0.00.00.00.00.0000 Contribuições 5.529.852,60 6.988.828,29 8.524.759,00 6.880.262,65 8.835.965,98 9.123.037,24 9.396.728,36 9.678.630,22 
+
+1.2.1.0.00.00.00.00.0000 Contribuições Sociais 2.426.849,93 3.554.310,73 3.796.579,30 3.804.719,00 3.930.479,54 4.063.027,98 4.184.918,82 4.310.466,39 
+
+1.2.1.0.04.00.00.00.0000 Contribuição para Regime Próprio de Previdência Social – RPPS 299.109,57 23.660,42 14.581,73 0,00 15.128,54 15.605,09 16.073,24 16.555,44 
+
+1.2.1.0.04.03.00.00.0000 Contribuição dos Servidores Inativos Civis para o RPPS 299.109,57 23.660,42 14.581,73 0,00 15.128,54 15.605,09 16.073,24 16.555,44 
+
+1.2.1.0.04.03.01.00.0000 Contribuição dos Servidores Inativos Civis para o RPPS – Principal 299.109,57 23.660,42 14.581,73 0,00 15.128,54 15.605,09 16.073,24 16.555,44 
+
+1.2.1.5.00.00.00.00.0000 Contribuições para Regimes Próprios de Previdência e Sistema de Proteção Social 2.127.740,36 3.530.650,31 3.781.997,57 3.804.719,00 3.915.351,00 4.047.422,89 4.168.845,58 4.293.910,95 
+
+1.2.1.5.01.00.00.00.0000 Contribuição do Servidor Civil 2.127.740,36 3.530.650,31 3.781.997,57 3.804.719,00 3.915.351,00 4.047.422,89 4.168.845,58 4.293.910,95 
+
+1.2.1.5.01.01.00.00.0000 Contribuição do Servidor Civil Ativo 2.127.740,36 3.530.650,31 3.781.997,57 3.804.719,00 3.915.351,00 4.047.422,89 4.168.845,58 4.293.910,95 
+
+1.2.1.5.01.01.01.00.0000 Contribuição do Servidor Civil Ativo – Principal 2.127.740,36 3.530.650,31 3.781.997,57 3.804.719,00 3.915.351,00 4.047.422,89 4.168.845,58 4.293.910,95 
+
+1.2.1.5.01.01.01.01.0000 Contribuição do Servidor Civil Ativo – Administração Direta 2.127.740,36 3.530.650,31 3.781.997,57 3.804.719,00 3.915.351,00 4.047.422,89 4.168.845,58 4.293.910,95 
+
+1.2.4.0.00.00.00.00.0000 Contribuição para Custeio do Serviço de Iluminação Pública 3.103.002,67 3.434.517,56 4.728.179,70 3.075.543,65 4.905.486,44 5.060.009,26 5.211.809,54 5.368.163,83 
+
+1.2.4.1.00.00.00.00.0000 Contribuição para Custeio do Serviço de Iluminação Pública 3.103.002,67 3.434.517,56 4.728.179,70 3.075.543,65 4.905.486,44 5.060.009,26 5.211.809,54 5.368.163,83 
+
+1.2.4.1.50.00.00.00.0000 Contribuição para Custeio do Serviço de Iluminação Pública 3.103.002,67 3.434.517,56 4.728.179,70 3.075.543,65 4.905.486,44 5.060.009,26 5.211.809,54 5.368.163,83 
+
+1.2.4.1.50.01.00.00.0000 Contribuição para Custeio do Serviço de Iluminação Pública 3.103.002,67 3.434.517,56 4.728.179,70 3.075.543,65 4.905.486,44 5.060.009,26 5.211.809,54 5.368.163,83 
+
+1.2.4.1.50.01.01.00.0000 Contribuição para Custeio do Serviço de Iluminação Pública – Principal 3.103.002,67 3.434.517,56 4.728.179,70 3.075.543,65 4.905.486,44 5.060.009,26 5.211.809,54 5.368.163,83 
+
+1.3.0.0.00.00.00.00.0000 Receita Patrimonial 313.180,00 229.574,42 1.034.929,77 299.638,78 1.101.056,25 1.107.562,42 1.140.789,28 1.175.012,97 
+
+1.3.2.0.00.00.00.00.0000 Valores Mobiliários 313.180,00 229.574,42 1.034.929,77 299.638,78 1.101.056,25 1.107.562,42 1.140.789,28 1.175.012,97 
+
+1.3.2.1.00.00.00.00.0000 Juros e Correções Monetárias 313.180,00 229.574,42 1.034.929,77 299.638,78 1.101.056,25 1.107.562,42 1.140.789,28 1.175.012,97 
+
+1.3.2.1.00.01.00.00.0000 Remuneração de Depósitos Bancários 313.180,00 229.574,42 1.034.929,77 299.638,78 1.101.056,25 1.107.562,42 1.140.789,28 1.175.012,97 
+
+1.3.2.1.00.01.01.00.0000 Remuneração de Depósitos Bancários – Principal 237.732,26 223.862,32 983.511,93 249.172,14 1.047.710,24 1.052.536,01 1.084.112,08 1.116.635,45 
+
+1.3.2.1.00.01.01.01.0000 RECEITA DE REMUNERAÇÃO DE DEPÓSITOS BANCÁRIOS DE RECURSOS VINCULADOS - ROYALTIES 321,82 0,00 0,00 138,99 0,00 0,00 0,00 0,00 
+
+1.3.2.1.00.01.01.02.0000 RECEITA DE REMUNERAÇÃO DE DEPÓSITOS BANCÁRIOS DE RECURSOS VINCULADOS – FUNDEB 5.209,05 5.963,72 94.407,69 7.720,50 97.947,98 101.033,34 104.064,34 107.186,27 
+
+1.3.2.1.00.01.01.03.0000 REMUNERAÇÃO DE DEPÓSITOS DOS RECURSOS FUNDO A FUNDO – SUS 36.493,82 20.047,98 84.640,29 43.231,22 87.814,30 90.580,45 93.297,86 96.096,79 
+
+1.3.2.1.00.01.01.03.0001 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE ATENÇÃO BÁSICA 29.720,16 3.150,81 41.435,15 9.733,06 42.988,97 44.343,12 45.673,41 47.043,61 
+
+1.3.2.1.00.01.01.03.0002 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE MÉDIA E ALTA COMPLEXIDADE 0,00 0,00 0,00 5.324,92 0,00 0,00 0,00 0,00 
+
+1.3.2.1.00.01.01.03.0003 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE VIGILÂNCIA EM SAÚDE 34,18 2,69 775,77 2.428,76 804,86 830,21 855,12 880,77 
+
+1.3.2.1.00.01.01.03.0004 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE ASSISTÊNCIA FARMACÊUTICA 0,00 16.352,00 0,00 1.854,02 0,00 0,00 0,00 0,00 
+
+1.3.2.1.00.01.01.03.0005 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE GESTÃO DO SUS 0,00 0,00 0,00 287,57 0,00 0,00 0,00 0,00 
+
+1.3.2.1.00.01.01.03.0006 REMUNEREAÇÃO DE DEPÓSITOS-BLOCO DE INVESTIMENTOS 4,824,22 235,77 34.963,99 22.558,89 36.276,14 37.417,81 383.540,34 39.696,55 
+
+1.3.2.1.00.01.01.03.0007 OUTRAS REMUNERAÇÕES DE DEPÓSITOS DESTINADOS A SAÚDE 1.915,26 5,12 0,23 0,00 0,24 0,25 0,26 0,27 
+
+1.3.2.1.00.01.01.03.0099 REMUNERAÇÃO DE APLICAÇÃO ASPS 0,00 301,59 7.465,15 1.044,00 7.745,09 7.989,06 8.228,73 8.475,59 
+
+1.3.2.1.00.01.01.04.0000 Remuneração de Depósitos Bancários – FNDE 188.301,84 182.107,18 779.486,92 181.095,19 808.717,68 834.192,27 859.218,03 884.994,57 
+
+1.3.2.1.00.01.01.04.0001 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO PNAE 1.066,80 222,02 2.665,23 5.434,00 2.765,18 2.852,28 2.937,85 3.025,99 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.3.2.1.00.01.01.04.0002 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO PNATE 415,42 532,27 2.179,03 100,00 2.260,74 2.331,95 2.401,91 2.473,97 
+
+1.3.2.1.00.01.01.04.0003 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO QSE 148,63 111.09 2.985,94 1.049,13 3.097,91 3.195,49 3.291,35 3.390,09 
+
+1.3.2.1.00.01.01.04.0004 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO-BRASIL ALFABETIZADO 97,01 12.195,05 773,37 449,71 802,37 827,64 852,47 878,04 
+
+1.3.2.1.00.01.01.04.0005 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO PAC i 5,51 6,91 0,39 13,69 0,40 0,41 0,42 0,43 
+
+1.3.2.1.00.01.01.04.0006 RENDIMENTOS DE APLICAÇÃO FINANCEIRA DO PAR 0,69 0,00 497,48 35,00 516,14 532,40 548,37 564,82 
+
+1.3.2.1.00.01.01.04.0008 Rendimentos de Aplicação CP 442,03 310,67 5.533,48 500,00 5.740,99 5.921,83 6.099,48 6.282,46 
+
+1.3.2.1.00.01.01.04.0098 Rendimentos de Aplicação – FUNDEF Precatórios 185.884,46 168.623,55 759.285,73 172.658,37 787.758,94 812.573,35 836.950,56 862.059,07 
+
+1.3.2.1.00.01.01.04.0099 RENDIMENTOS DE APLICAÇÃO FINANCEIRA OUTROS FNDE 241,29 105,62 5.566,27 855,29 5.775,01 5.956,92 6.135,63 6.319,70 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     39 
+ 
+
+1.3.2.1.00.01.01.05.0000 RECEITA DE REMUNERAÇÃO DE DEPÓSITOS BANCÁRIOS DE RECURSOS DO FNAS 3.126,12 11.503,08 15.979,42 6.060,87 16.578,66 17.100,88 17.613,91 18.142,33 
+
+1.3.2.1.00.01.01.06.0000 RENDIMENTOS DE APLICAÇÃO FINANCEIRA – SAAE 2.337,27 0,00 1.397,03 1.099,84 1.449,42 1.495,08 1.539,93 1.586,13 
+
+1.3.2.1.00.01.01.07.0000 RENDIMENTOS DE APLICAÇÃO FINANCEIRA – FMT 3.845,73 71,85 3.746,32 2.183,52 3.886,81 4.009,24 4.129,52 4.253,41 
+
+1.3.2.1.00.01.01.08.0000 Rendimentos de Aplicação – SMTT 0,00 425,00 77.94 3.686,01 80.86 83.41 85.91 88,49 
+
+1.3.2.1.00.01.01.24.0000 Rec. De Rem. De Dep. Banc Rec. Vinc – RPPS -1.943,39 3.742,91 3.776,32 3.956,00 31.234,54 4.041,34 4.162,58 4,287,46 
+
+1.3.2.1.00.01.02.00.0000 RECEITA DE REMUNEAÇÃO DE OUTROS DEPÓSITOS DE RECURSOS NÃO VINCULADOS 75.447,74 5.712,10 51.417,84 50.466,64 53.346,01 55.026,41 56.677,20 58.377,52 
+
+1.6.0.0.00.00.00.00.0000 Receita de Serviços 2.474.388,22 1.810.002,49 2.531.426,94 2.089.234,73 2.626.355,45 2.709.085,65 2.790.358,21 2.874.068,96 
+
+1.6.1.0.00.00.00.00.0000 Serviços Administrativos e Comerciais Gerais 2.474.388,22 1.810.002,49 2.531.426,94 2.030.777,87 2.626.355,45 2.709.085,65 2.790.358,21 2.874.068,96 
+
+1.6.1.0.01.00.00.00.0000 Serviços Administrativos e Comerciais Gerais 1.212.902,24 262.496,07 1.907.883,12 1.711.082,40 1.979.376.86 2.041.727,23 2.102.979,04 2.166.068,41 
+
+1.6.1.0.01.01.00.00.0000 Serviços Administrativos e Comerciais Gerais 1.212.902,24 262.496,07 1.907.883,12 1.711.082,40 1.979.376.86 2.041.727,23 2.102.979,04 2.166.068,41 
+
+1.6.1.0.01.01.01.00.0000 Serviços Administrativos e Comerciais Gerais 1.212.902,24 262.496,07 1.907.883,12 1.711.082,40 1.979.376.86 2.041.727,23 2.102.979,04 2.166.068,41 
+
+1.6.1.0.01.01.01.01.0000 SERVIÇOS DE LIGAÇÃO DE ÁGUA E ESGOTO 952.370,98 262.496,07 7.120,74 465.564,95 7.387,77 7.620,48 7.849,09 8.084,56 
+
+1.6.1.0.01.01.01.03.0000 SERVIÇO DE CAPTAÇÃO, ADUÇÃO, TRATAMENTO, RESERVAÇÃO E DISTRIBUIÇÃO DE ÁGUA 260.531,26 0,00 1.900.712,38 1.245.517,45 1.971.989,09 2.034.106,75 2.095.129,95 2.157.983,85 
+
+1.6.1.0.03.00.00.00.0000 Serviços de Registro, Certificação e Fiscalização 1.261.485,98 1.547.506,42 623.593,82 319.695,47 646.978,59 667.358,42 687.379,17 708.000,55 
+
+1.6.1.0.03.01.00.00.0000 Serviços de Registro, Certificação e Fiscalização 1.261.485,98 1.547.506,42 623.593,82 319.695,47 646.978,59 667.358,42 687.379,17 708.000,55 
+
+1.6.1.0.03.01.01.00.0000 Serviços de Registro, Certificação e Fiscalização - Fiscalização 1.261.485,98 1.547.506,42 623.593,82 319.695,47 646.978,59 667.358,42 687.379,17 708.000,55 
+
+1.6.9.0.00.00.00.00.0000 Outros Serviços 0,00 0,00 0,00 58.456,86 0,00 0,00 0,00 0,00 
+
+1.6.9.0.99.00.00.00.0000 Outros Serviços 0,00 0,00 0,00 58.456,86 0,00 0,00 0,00 0,00 
+
+1.6.9.0.99.01.00.00.0000 Outros Serviços 0,00 0,00 0,00 58.456,86 0,00 0,00 0,00 0,00 
+
+1.6.9.0.99.01.01.00.0000 Outros Serviços - Principal 0,00 0,00 0,00 58.456,86 0,00 0,00 0,00 0,00 
+
+1.7.0.0.00.00.00.00.0000 Transferências Correntes 109.109.276,48 85.615.617,36 107.789.165,83 97.214.348,03 112.391.820,36 115.353.944,25 118.814.562,61 122.378.999,47 
+
+1.7.1.0.00.00.00.00.0000 Transferências da União e de Suas Entidades 42.501.659,77 52.810.015,14 64.295.383,72 52.662.462,96 67.267.021,41 68.807.714,12 70.871.945,57 72.998.103,84 
+
+1.7.1.1.00.00.00.00.0000 Transferências Decorrentes da Participação na Receita da União 22.155.180,72 22.091.759,65 28.544.392,46 25.152.317,78 29.614.807,19 30.547.673,61 31.464.103,83 32.408.026,95 
+
+1.7.1.1.51.00.00.00.0000 Cota-Parte do Fundo de Participação dos Municípios – FPM 22.124.977,30 21.910.197,91 28.527.106,29 24.996.746,74 29.596.872,78 30.529.174,27 31.445.049,51 32.388.401,00 
+
+1.7.1.1.51.01.00.00.0000 Cota-Parte do Fundo de Participação dos Municípios – Cota Mensal 24.862.570,42 24.544.137,92 32.351.853,52 28.178.048,40 33.596.872,78 34.622.347,04 35.661.017,45 36.730.847,97 
+
+1.7.1.1.51.01.01.00.0000 Cota-Parte do Fundo de Participação dos Municípios – Cota Mensal – Principal 24.862.570,42 24.544.137,92 32.351.853,52 28.178.048,40 33.596.872,78 34.622.347,04 35.661.017,45 36.730.847,97 
+
+1.7.1.1.51.02.00.00.0000 Cota-Parte do Fundo de Participação dos Municípios 1% Cota Entregue no mês dezembro 1.097.228,39 1.068.188,18 1.403.949,27 1.225.745,11 1.456.597,37 1.502.480,19 1.547.554,60 1.593.981,24 
+
+1.7.1.1.51.02.01.00.0000 Cota-Parte do Fundo de Participação dos Municípios 1% Cota Entregue no mês dezembro 1.097.228,39 1.068.188,18 1.403.949,27 1.225.745,11 1.456.597,37 1.502.480,19 1.547.554,60 1.593.981,24 
+
+1.7.1.1.51.03.00.00.0000 Cota-Parte do Fundo de Participação dos Municípios 1% Cota Entregue no mês Junho 1.056.690,93 1.070.466,58 1.240.175,14 1.228.562,91 1.286.681,71 1.327.212,18 1.367.028,55 1.408.039,41 
+
+1.7.1.1.51.03.01.00.0000 Cota-Parte do Fundo de Participação dos Municípios 1% Cota Entregue no mês Junho 1.056.690,93 1.070.466,58 1.240.175,14 1.228.562,91 1.286.681,71 1.327.212,18 1.367.028,55 1.408.039,41 
+
+1.7.1.1.51.99.00.00.0000 (-) Dedução Fundeb – Cota Parte do Fundo de Participação dos Municípios -4.891.512,44 -4.772.593,77 -6.468.817,64 -5.635.609,68 -6.711.454,33 -6.922.865,14 -7.130.551,09 -7.344.467,62 
+
+1.7.1.1.51.99.01.00.0000 (-) Dedução Fundeb – Cota Parte do Fundo de Participação dos Municípios -4.891.512,44 -4.772.593,77 -6.468.817,64 -5.635.609,68 -6.711.454,33 -6.922.865,14 -7.130.551,09 -7.344.467,62 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.7.1.1.52.00.00.00.0000 Cota-Parte do Imposto Sobre a Propriedade Territorial Rural 30.203,42 181.561,74 17.286,17 155.571,04 17.934,41 18.499,34 19.054,32 19.625,96 
+
+1.7.1.1.52.01.00.00.0000 Cota-Parte do Imposto Sobre a Propriedade Territorial Rural 37.422,91 187.887,73 21.607,62 194.463,80 22.417,91 23.124,07 23.817,79 24.532,32 
+
+1.7.1.1.52.01.01.00.0000 Cota-Parte do Imposto Sobre a Propriedade Territorial Rural – Principal 37.422,91 187.887,73 21.607,62 194.463,80 22.417,91 23.124,07 23.817,79 24.532,32 
+
+1.7.1.1.52.99.00.00.0000 (-) Dedução do FUNDEB – Cota-Parte do Imposto Sobre a Propriedade Territorial Rural -7.219,49 -6.325,99 -4.321,45 -38.892,76 -4.483,50 -4.624,73 -4.763,47 -4.906,37 
+
+1.7.1.1.52.99.01.00.0000 (-) Dedução do FUNDEB – Cota-Parte do Imposto Sobre a Propriedade Territorial Rural -7.219,49 -6.325,99 -4.321,45 -38.892,76 -4.483,50 -4.624,73 -4.763,47 -4.906,37 
+
+1.7.1.2.00.00.00.00.0000 Transferências das Compensações Financeiras pela Exploração de Recursos Naturais 407.695,23 409.704,16 643.243,97 473.447,92 667.365,62 688.387,64 709.039,27 730.310,45 
+
+1.7.1.2.51.00.00.00.0000 Cota-Parte da Compensação Financeira pela Exploração de Recursos Minerais - CFEM 76.416,42 4.480,01 4.513,59 38.482,92 4.682,85 4.830,36 4.975,27 5.124,53 
+
+1.7.1.2.51.01.00.00.0000 Cota-Parte da Compensação Financeira pela Exploração de Recursos Minerais – CFEM 76.416,42 4.480,01 4.513,59 38.482,92 4.682,85 4.830,36 4.975,27 5.124,53 
+
+1.7.1.2.51.01.01.00.0000 Cota-Parte da Compensação Financeira pela Exploração de Recursos Minerais – CFEM 76.416,42 4.480,01 4.513,59 38.482,92 4.682,85 4.830,36 4.975,27 5.124,53 
+
+1.7.1.2.52.00.00.00.0000 Cota-Parte da Compensação Financeira pela Produção de Petróleo 331.278,81 405.224,15 638.730,38 438.965,00 662.682,77 683.557,28 704.064,00 725.185,92 
+
+1.7.1.2.52.01.00.00.0000 Cota-Parte da Compensação Financeira pela Produção de Petróleo Lei nº 7.990/89 13.998,21 23.622,56 19.558,16 28.134,08 20.291,59 20.930,78 21.558,70 22.205,46 
+
+1.7.1.2.52.01.01.00.0000 Cota-Parte da Compensação Financeira pela Produção de Petróleo Lei nº 7.990/89 13.998,21 23.622,56 19.558,16 28.134,08 20.291,59 20.930,78 21.558,70 22.205,46 
+
+1.7.1.2.52.04.00.00.0000 Cota-Parte do Fundo Especial do Petróleo - FEP 317.280,60 381.601,59 619.172,22 406.830,92 642.391,18 682.505,30 682.505,30 702.980,46 
+
+1.7.1.2.52.04.01.00.0000 Cota-Parte do Fundo Especial do Petróleo – FEP 317.280,60 381.601,59 619.172,22 406.830,92 642.391,18 682.505,30 682.505,30 702.980,46 
+
+1.7.1.3.00.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde - SUS 12.456.278,94 16.522.094,43 17.969.110,67 12.274.087,01 18.642.952,31 19.807.111,48 19.807.111,48 20.401.324,82 
+
+1.7.1.3.00.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde - SUS 12.456.278,94 16.522.094,43 17.969.110,67 12.274.087,01 18.642.952,31 19.807.111,48 19.807.111,48 20.401.324,82 
+
+1.7.1.3.50.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS – Repasses Fundo a Fundo – Bloco de Manut. Da 12.456.278,94 16.106.611,57 17.969.110,67 11.844.062,25 18.642.952,31 19.807.111,48 19.807.111,48 20.401.324,82 
+
+1.7.1.3.50.01.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Atenção Primária 6.636.715,35 5.005.214,82 8.945.265,05 3.993.302,58 9.928.712,49 9.573.054,93 9.860.246,58 10.156.053,98 
+
+1.7.1.3.50.01.01.01.0000 Transferências de Fundo a Fundo – Atenção Primária 6.636.715,35 5.005.214,82 8.945.265,05 3.993.302,58 9.928.712,49 9.573.054,93 9.860.246,58 10.156.053,98 
+
+1.7.1.3.50.01.01.02.0000 Transferências de Fundo a Fundo – Agentes Comunitários 0,00 0,00 0,00 204.600,00 0,00 0,00 0,00 0,00 
+
+1.7.1.3.50.02.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Atenção Especializ. 5.314.211,87 6.437.629,52 6.804.817,45 6.700.891,57 7.059.998,10 7.282.388,04 7.500.859,68 7.725.885,47 
+
+1.7.1.3.50.02.01.00.0000 Transferências de Fundo a Fundo – Média e Alta Complexidade 5.314.211,87 6.437.629,52 6.804.817,45 6.700.891,57 7.059.998,10 7.282.388,04 7.500.859,68 7.725.885,47 
+
+1.7.1.3.50.03.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Vigilância em Sal 309.718,36 359.454,33 328.584,88 413.063,31 340.906,81 351.645,37 362.194,73 373.060,57 
+
+1.7.1.3.50.03.01.00.0000 Transferências Fundo a Fundo – Vigilância em Saúde 309.718,36 359.454,33 328.584,88 413.063,31 340.906,81 351.645,37 362.194,73 373.060,57 
+
+1.7.1.3.50.04.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Assist. Farmacêutica 171.633,36 179.872,00 196.224,00 217.033,94 203.582,40 209.996,25 216.295,11 222.783,96 
+
+1.7.1.3.50.04.01.00.0000 Transferências Fundo a Fundo – Assistência Farmacêutica 171.633,36 179.872,00 196.224,00 217.033,94 203.582,40 209.996,25 216.295,11 222.783,96 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     40 
+ 
+
+1.7.1.3.50.05.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Gestão do SUS 24.000,00 12.000,00 12.000,00 22.983,17 12.450,00 12.842,18 13.227,45 13.624,27 
+
+1.7.1.3.50.05.01.00.0000 Transferências Fundo a Fundo – Gestão do SUS 24.000,00 12.000,00 12.000,00 22.983,17 12.450,00 12.842,18 13.227,45 13.624,27 
+
+1.7.1.3.50.09.00.00.0000 Transferências de Recursos do Bloco de Manutenção das Ações e Serviços Públicos de Saúde – Outros Programas 0,00 4.112.440,90 1.682.219,29 496.787,68 1.745.302,51 1.800.279,54 1.854.287,93 1.909.916,57 
+
+1.7.1.3.50.09.01.00.0000 Transferências Fundo a Fundo – Outros Programas 0,00 4.112.440,90 1.682.219,29 496.787,68 1.745.302,51 1.800.279,54 1.854.287,93 1.909.916,57 
+
+1.7.1.3.51.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS – Repasses Fundo a Fundo – Bloco de Estruturação d 0,00 415.482,86 0,00 430.024,76 0,00 0,00 0,00 0,00 
+
+1.7.1.3.51.01.00.00.0000 Transferências de Recursos do Bloco de Estruturação da Rede de Serviços Públicos de Saúde – Atenção Primária 0,00 415.482,86 0,00 430.024,76 0,00 0,00 0,00 0,00 
+
+1.7.1.4.00.00.00.00.0000 Transferências de Recursos do Fundo Nacional do Desenvolvimento da Educação – FNDE 1.318.677,88 1.327.652,00 1.656.172,61 1.607.759,71 1.718.279,08 1.772.404,87 1.825.577,01 1.880.344,32 
+
+1.7.1.4.50.00.00.00.0000 Transferências do Salário-Educação 551.654,76 493.780,06 557.686,22 654.715,58 578.599,45 596.825,33 614.730,09 633.171,99 
+
+1.7.1.4.50.01.00.00.0000 Transferências do Salário-Educação 551.654,76 493.780,06 557.686,22 654.715,58 578.599,45 596.825,33 614.730,09 633.171,99 
+
+1.7.1.4.50.01.01.00.0000 Transferências do Salário-Educação 551.654,76 493.780,06 557.686,22 654.715,58 578.599,45 596.825,33 614.730,09 633.171,99 
+
+1.7.1.4.52.00.00.00.0000 Transferências referentes ao Programa Nacional de Alimentação Escolar - PNAE 632.651,40 770.638,00 644.978,40 669.165,09 690.243,79 690.243,79 710.951,10 732.279,63 
+
+1.7.1.4.52.01.00.00.0000 Transferências referentes ao Programa Nacional de Alimentação Escolar – PNAE 632.651,40 770.638,00 644.978,40 669.165,09 690.243,79 690.243,79 710.951,10 732.279,63 
+
+1.7.1.4.52.01.01.00.0000 Transferências referentes ao Programa Nacional de Alimentação Escolar – PNAE 632.651,40 770.638,00 644.978,40 669.165,09 690.243,79 690.243,79 710.951,10 732.279,63 
+
+1.7.1.4.53.00.00.00.0000 Transferências referentes ao Programa Nacional de Apoio ao Transporte do Escolar - PNATE 132.400,72 61.493,94 224.595,99 101.721,08 240.358,42 240.358,42 247.569,17 254.996,25 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.7.1.4.53.01.00.00.0000 Transferências referentes ao Programa Nacional de Apoio ao Transporte do Escolar - PNATE 132.400,72 61.493,94 224.595,99 101.721,08 233.018,34 240.358,42 247.569,17 254.996,25 
+
+1.7.1.4.53.01.01.00.0000 Transferências referentes ao Programa Nacional de Apoio ao Transporte do Escolar - PNATE 132.400,72 61.493,94 224.595,99 101.721,08 233.018,34 240.358,42 247.569,17 254.996,25 
+
+1.7.1.4.99.00.00.00.0000 Outras Transferências Diretas do Fundo Nacional do Desenvolvimento da Educação - FNDE 1.980,00 1.740,00 228.912,00 66.509,79 237.496,20 244.977,33 252.326,65 259.896,45 
+
+1.7.1.4.99.01.00.00.0000 Outras Transferências Diretas do Fundo Nacional do Desenvolvimento da Educação – FNDE 1.980,00 1.740,00 228.912,00 66.509,79 237.496,20 244.977,33 252.326,65 259.896,45 
+
+1.7.1.4.99.01.01.00.0000 Outras Transferências Diretas do Fundo Nacional do Desenvolvimento da Educação – FNDE 1.980,00 1.740,00 228.912,00 66.509,79 237.496,20 244.977,33 252.326,65 259.896,45 
+
+1.7.1.5.00.00.00.00.0000 
+Transferências de Recursos de Complementação da União ao Fundo de Manutenção e 
+Desenvolvimento da Educação 
+
+4.294.771,05 5.677.825,56 6.633.501,13 9.444.062,70 6.882.257,42 7.099.048,53 7.312.019,99 7.531.380,59 
+
+1.7.1.5.51.00.00.00.0000 Transferência de Recursos de Complementação da União ao Fundeb - VAAF 4.294.771,05 5.677.825,56 6.633.501,13 9.444.062,70 6.882.257,42 7.099.048,53 7.312.019,99 7.531.380,59 
+
+1.7.1.5.51.01.00.00.0000 Transferência de Recursos de Complementação da União ao Fundeb – VAAF 4.294.771,05 5.677.825,56 6.633.501,13 9.444.062,70 6.882.257,42 7.099.048,53 7.312.019,99 7.531.380,59 
+
+1.7.1.5.51.01.01.00.0000 Transferência de Recursos de Complementação da União ao Fundeb – VAAF 4.294.771,05 5.677.825,56 6.633.501,13 9.444.062,70 6.882.257,42 7.099.048,53 7.312.019,99 7.531.380,59 
+
+1.7.1.7.00.00.00.00.0000 Transferências de Convênios da União e de Suas Entidades 0,00 386.203,55 0,00 0,00 560.560,80 0,00 0,00 0,00 
+
+1.7.1.7.99.00.00.00.0000 Outras Transferências de Convênios da União e de Suas Entidades 0,00 386.203,55 0,00 0,00 560.560,80 0,00 0,00 0,00 
+
+1.7.1.7.99.01.00.00.0000 Outras Transferências de Convênios da União e de Suas Entidades 0,00 386.203,55 0,00 0,00 560.560,80 0,00 0,00 0,00 
+
+1.7.1.8.00.00.00.00.0000 Transferências da União – Específica 569.028,99 943.522,48 544.946,96 977.546,23 565.382,47 583.192,02 600.687,79 618.708,42 
+
+1.7.1.8.04.00.00.00.0000 Transferências de Recursos do Fundo Nacional de Assistência Social - FNAS 569.028,99 943.522,48 544.946,96 977.546,23 565.382,47 583.192,02 600.687,79 618.708,42 
+
+1.7.1.8.04.01.00.00.0000 Transferências de Recursos do Fundo Nacional de Assistência Social – FNAS 569.028,99 943.522,48 544.946,96 977.546,23 565.382,47 583.192,02 600.687,79 618.708,42 
+
+1.7.1.8.04.01.01.00.0000 Transferências de Recursos do Fundo Nacional de Assistência Social – FNAS – Principal 569.028,99 943.522,48 544.946,96 977.546,23 565.382,47 583.192,02 600.687,79 618.708,42 
+
+1.7.1.8.04.01.01.01.0000 Proteção Social Básica – PSB/PBF/CRAS 162.058,00 472.432,91 191.879,55 306.155,91 199.075,03 205.345,89 211.506,27 217.851,46 
+
+1.7.1.8.04.01.01.02.0000 Índice de Gestão Descentralizada – IGD/PBF 133.199,51 152.131,96 139.728,00 127.841,28 144.968,42 149.534,93 154.020,98 158.641,61 
+
+1.7.1.8.04.01.01.03.0000 Índice de Gestão Descentralizada do Suas – IGD/SUAS 6.434,19 0,00 7.698,00 22.482,79 7.986,68 8.238,26 8.485,41 8.739,97 
+
+1.7.1.8.04.01.01.04.0000 Piso Fixo de Média Complexidade – CREAS 87.016,41 124.463,59 43.836,80 94.402,29 45.480,68 46.913,32 48.320,72 49.770,34 
+
+1.7.1.8.04.01.01.05.0000 Serviços de Convivência e Fortalecimento de Vínculos – SCFV 180.320,88 24.488,02 0,00 106.074,66 0,00 0,00 0,00 0,00 
+
+1.7.1.8.04.01.01.06.0000 Programa Primeira Infância – Criança Feliz 0,00 170.006,00 160.155,00 320.629,30 166.150,81 171.394,88 176.530,73 181.832,83 
+
+1.7.1.8.04.01.01.07.0000 Programa de Benefício de Prestação Continuada – BPC 0,00 0,00 1.649,01 0,00 1.710,85 1.764,74 1.817,68 1.872,21 
+
+1.7.1.9.00.00.00.00.0000 Outras Transferências de Recursos da União e de Suas Entidades 1.300.026,96 6.451.253,31 8.304.015,92 2.733.241,61 8.615.415,53 8.886.802,14 9.153.406,20 9.428.008,39 
+
+1.7.1.9.50.00.00.00.0000 Outras Transferências de Recursos da União e de Suas Entidades 1.300.026,96 6.451.253,31 8.304.015,92 2.733.241,61 8.615.415,53 8.886.802,14 9.153.406,20 9.428.008,39 
+
+1.7.1.9.50.01.00.00.0000 Outras Transferências de Recursos da União e de Suas Entidades 1.300.026,96 6.451.253,31 8.304.015,92 2.733.241,61 8.615.415,53 8.886.802,14 9.153.406,20 9.428.008,39 
+
+1.7.1.9.50.01.01.00.0000 Outras Transferências de Recursos da União e de Suas Entidades 1.300.026,96 6.451.253,31 8.304.015,92 2.733.241,61 8.615.415,53 8.886.802,14 9.153.406,20 9.428.008,39 
+
+1.7.2.0.00.00.00.00.0000 Transferências dos Estados e do Distrito Federal e de Suas Entidades 9.218.644,36 11.906.473,14 15.368.291,96 12.497.207,83 15.944.602,92 16.446.857,93 16.940.263,68 17.448.471,57 
+
+1.7.2.1.00.00.00.00.0000 Participação na Receita dos Estados e Distrito Federal 7.370.203,79 9.749.131,47 13.000.426,29 10.077.030,36 13.487.942,28 13.912.812,46 14.330.196,84 14.760.102,73 
+
+1.7.2.1.50.00.00.00.0000 Cota-Parte do ICMS 6.727.702,69 9.008.589,74 12.210.506,36 9.306.707,73 12.668.400,35 13.067.454,96 13.459.478,61 13.863.262,97 
+
+1.7.2.1.50.01.00.00.0000 Cota-Parte do ICMS 8.409.628,44 11.241.071,27 15.276.368,24 11.633.384,66 15.849.232,05 16.348.482,86 16.838.937,35 17.344.105,47 
+
+1.7.2.1.50.01.01.00.0000 Cota-Parte do ICMS 8.409.628,44 11.241.071,27 15.276.368,24 11.633.384,66 15.849.232,05 16.348.482,86 16.838.937,35 17.344.105,47 
+
+1.7.2.1.50.99.00.00.0000 (-) Dedução do FUNDEB - Cota-Parte do ICMS -1.681.925,75 -2.232.481,53 -3.065.861,88 -2.326.675,93 -3.180.831,70 -3.281.027,90 -3.379.458,74 -3.480.842,50 
+
+1.7.2.1.50.99.01.00.0000 (-) Dedução do FUNDEB - Cota-Parte do ICMS -1.681.925,75 -2.232.481,53 -3.065.861,88 -2.326.675,93 -3.180.831,70 -3.281.027,90 -3.379.458,74 -3.480.842,50 
+
+1.7.2.1.51.00.00.00.0000 Cota-Parte do IPVA 582.695,32 678.529,09 770.635,15 692.843,34 799.533,97 824.719,29 849.460,87 874.944,69 
+
+1.7.2.1.51.01.00.00.0000 Cota-Parte do IPVA 725.192,79 836.767,31 947.129,35 866.054,17 982.646,70 1.013.600,07 1.044.008,07 1.075.328,31 
+
+1.7.2.1.51.01.00.00.0000 Cota-Parte do IPVA 725.192,79 836.767,31 947.129,35 866.054,17 982.646,70 1.013.600,07 1.044.008,07 1.075.328,31 
+
+1.7.2.1.51.99.00.00.0000 (-) Dedução FUNDEB - Cota-Parte do IPVA -142.497,47 -158.238,22 -176.494,20 -173.210,83 -183.112,73 -188.884,78 -194.547,20 -200.383,62 
+
+1.7.2.1.51.99.01.00.0000 (-) Dedução FUNDEB - Cota-Parte do IPVA -142.497,47 -158.238,22 -176.494,20 -173.210,83 -183.112,73 -188.884,78 -194.547,20 -200.383,62 
+
+1.7.2.1.52.00.00.00.0000 Cota-Parte do IPI - Municípios 29.254,08 36.361,34 2.439,43 37.081,26 2.530,91 2.610,63 2.688,86 2.769,61 
+
+  
+ 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     41 
+ 
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.7.2.1.52.01.00.00.0000 Cota-Parte do IPI - Municípios 36.554,62 45.099,38 7.852,27 46.351,57 8.146,73 8.403,35 8.655,45 8.915,11 
+
+1.7.2.1.52.01.01.00.0000 Cota-Parte do IPI – Municípios 36.554,62 45.099,38 7.852,27 46.351,57 8.146,73 8.403,35 8.655,45 8.915,11 
+
+1.7.2.1.52.99.00.00.0000 (-) Dedução FUNDEB - Cota-Parte do IPI - Municípios -7.300,54 -8.738,04 -5.412,84 -9.270,31 -5.615,82 -5.792,72 -5.966,50 -6.145,50 
+
+1.7.2.1.52.99.01.00.0000 (-) Dedução FUNDEB - Cota-Parte do IPI – Municípios -7.300,54 -8.738,04 -5.412,84 -9.270,31 -5.615,82 -5.792,72 -5.966,50 -6.145,50 
+
+1.7.2.1.53.00.00.00.0000 Cota-Parte da Contribuição de Intervenção no Domínio Econômico 30.551,70 25.651,30 16.845,35 40.398,03 17.477,05 18.027,58 18.568,41 19.125,46 
+
+1.7.2.1.53.01.00.00.0000 Cota-Parte da Contribuição de Intervenção no Domínio Econômico 30.551,70 25.651,30 16.845,35 40.398,03 17.477,05 18.027,58 18.568,41 19.125,46 
+
+1.7.2.1.53.01.01.00.0000 Cota-Parte da Contribuição de Intervenção no Domínio Econômico 30.551,70 25.651,30 16.845,35 40.398,03 17.477,05 18.027,58 18.568,41 19.125,46 
+
+1.7.2.2.00.00.00.00.0000 Transferências das Compensações Financeiras pela Exploração de Recursos Naturais 32.664,00 33.206,13 52.604,40 27.828,74 54.577,07 56.296,25 57.985,14 59.724,69 
+
+1.7.2.2.52.00.00.00.0000 Cota-Parte Royalties – Compensação Financeira pela Produção do Petróleo 32.664,00 33.206,13 52.604,40 27.828,74 54.577,07 56.296,25 57.985,14 59.724,69 
+
+1.7.2.2.52.01.00.00.0000 Cota-Parte Royalties – Compensação Financeira pela Produção do Petróleo 32.664,00 33.206,13 52.604,40 27.828,74 54.577,07 56.296,25 57.985,14 59.724,69 
+
+1.7.2.1.52.01.01.00.0000 Cota-Parte Royalties – Compensação Financeira pela Produção do Petróleo 32.664,00 33.206,13 52.604,40 27.828,74 54.577,07 56.296,25 57.985,14 59.724,69 
+
+1.7.2.3.00.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 1.322.477,91 1.987.239,54 1.754.515,27 1.784.523,43 1.820.309,59 1.877.649,36 1.933.978,84 1.991.998,20 
+
+1.7.2.3.50.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 1.322.477,91 1.987.239,54 1.754.515,27 1.784.523,43 1.820.309,59 1.877.649,36 1.933.978,84 1.991.998,20 
+
+1.7.2.3.50.01.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 1.322.477,91 1.987.239,54 1.754.515,27 1.784.523,43 1.820.309,59 1.877.649,36 1.933.978,84 1.991.998,20 
+
+1.7.2.3.50.01.01.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 1.322.477,91 1.987.239,54 1.754.515,27 1.784.523,43 1.820.309,59 1.877.649,36 1.933.978,84 1.991.998,20 
+
+1.7.2.3.50.01.01.01.0000 SESAU – Bloco de Atenção Básica 74.418,00 0,00 50.859,29 42.470,71 52.766,51 54.428,66 56.061,52 57.743,37 
+
+1.7.2.3.50.01.01.02.0000 SESAU – Bloco de Média e Alta Complexidade 1.025.875,00 1.448.250,00 1.468.796,79 1.536.623,48 1.523.876,67 1.571.878,79 1.619.035,15 1.667.606,20 
+
+1.7.2.3.50.01.01.03.0000 SESAU – Bloco de Vigilância em Saúde 131.580,99 52.048,59 83.512,41 94.322,93 86.644,13 89.373,42 92.054,62 94.816,26 
+
+1.7.2.3.50.01.01.04.0000 SESAU – Bloco de Assistência Farmacêutica 36.403,92 55.528,44 45.432,36 59.563,15 47.136,07 48.620,86 50.079,49 51.581,87 
+
+1.7.2.3.50.01.01.05.0000 SESAU – Bloco de Estruturação – Atenção Primária 54.200,00 81.412,51 105.914,42 51.543,16 109.886,21 113.347,63 116.748,06 120.250,50 
+
+1.7.2.3.50.01.01.98.0000 SESAU – Outras Transferências 0,00 350.000,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.7.2.9.00.00.00.00.0000 Outras Transferências dos Estados e Distrito Federal 493.298,66 136.896,00 560.746,00 607.825,30 581.773,96 600.099,86 618.102,86 636.645,95 
+
+1.7.2.9.52.00.00.00.0000 Transferências de Recursos Destinados a Programas de Educação 415.536,00 136.896,00 547.281,00 425.030,43 567.804,04 585.689,87 603.260,57 621.358,39 
+
+1.7.2.9.52.01.00.00.0000 GEITE – Gestão Integrada de Transporte Escolar 415.536,00 136.896,00 547.281,00 425.030,43 567.804,04 585.689,87 603.260,57 621.358,39 
+
+1.7.2.9.52.01.01.00.0000 GEITE – Gestão Integrada de Transporte Escolar 415.536,00 136.896,00 547.281,00 425.030,43 567.804,04 585.689,87 603.260,57 621.358,39 
+
+1.7.2.9.53.00.00.00.0000 Transferências do Estado para Assistência Social - CRAS 0,00 0,00 13.465,00 20.106,03 13.969,94 14.409,99 14.842,29 15.287,56 
+
+1.7.2.9.53.01.00.00.0000 Transferências do Estado para Assistência Social - CRAS 0,00 0,00 13.465,00 20.106,03 13.969,94 14.409,99 14.842,29 15.287,56 
+
+1.7.2.9.53.01.01.00.0000 Transferências do Estado para Assistência Social – CRAS 0,00 0,00 13.465,00 20.106,03 13.969,94 14.409,99 14.842,29 15.287,56 
+
+1.7.2.9.99.00.00.00.0000 Outras Transferências dos Estados e DF 77.762,66 0,00 0,00 162.688,84 0,00 0,00 0,00 0,00 
+
+1.7.2.9.99.01.00.00.0000 Outras Transferências dos Estados e DF 77.762,66 0,00 0,00 162.688,84 0,00 0,00 0,00 0,00 
+
+1.7.2.9.99.01.01.00.0000 Outras Transferências dos Estados e DF 77.762,66 0,00 0,00 162.688,84 0,00 0,00 0,00 0,00 
+
+1.7.3.0.00.00.00.00.0000 Transferências dos Municípios e de suas Entidades 172.500,00 243.450,00 429.000,00 213.081,05 445.087,50 459.107,76 472.880,99 487.067,42 
+
+1.7.3.9.00.00.00.00.0000 Outras Transferências dos Municípios 172.500,00 243.450,00 429.000,00 213.081,05 445.087,50 459.107,76 472.880,99 487.067,42 
+
+1.7.3.9.99.00.00.00.0000 Outras Transferências dos Municípios 172.500,00 243.450,00 429.000,00 213.081,05 445.087,50 459.107,76 472.880,99 487.067,42 
+
+1.7.3.9.99.01.00.00.0000 Outras Transferências dos Municípios 172.500,00 243.450,00 429.000,00 213.081,05 445.087,50 459.107,76 472.880,99 487.067,42 
+
+1.7.3.9.99.01.01.00.0000 Outras Transferências dos Municípios 172.500,00 243.450,00 429.000,00 213.081,05 445.087,50 459.107,76 472.880,99 487.067,42 
+
+1.7.4.0.00.00.00.00.0000 Transferências de Instituições Privadas 0,00 279.962,65 203.613,53 452.440,67 211.249,04 217.903,38 224.440,48 231.173,69 
+
+1.7.4.1.00.00.00.00.0000 Transferências de Instituições Privadas 0,00 279.962,65 203.613,53 452.440,67 211.249,04 217.903,38 224.440,48 231.173,69 
+
+1.7.4.1.99.00.00.00.0000 Outras Transferências de Instituições Privadas 0,00 279.962,65 203.613,53 452.440,67 211.249,04 217.903,38 224.440,48 231.173,69 
+
+1.7.4.1.99.01.00.00.0000 Outras Transferências de Instituições Privadas 0,00 279.962,65 203.613,53 452.440,67 211.249,04 217.903,38 224.440,48 231.173,69 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+1.7.4.1.99.01.01.00.0000 Outras Transferências de Instituições Privadas 0,00 279.962,65 203.613,53 452.440,67 211.249,04 217.903,38 224.440,46 231.173,69 
+
+1.7.5.0.00.00.00.00.0000 Transferências de Outras Instituições Públicas 57.216.472,35 20.375.716,42 27.492.876,62 31.389.155,52 28.523.859,49 29.422.361,06 30.305.031,89 31.214.182,85 
+
+1.7.5.1.00.00.00.00.0000 Transferências de Recursos do Fundo de Manutenção e Desenvolvimento da Educação Básica e de Valorização dos Pr 15.991.984,72 20.375.716,42 27.492.876,62 31.389.155,52 28.523.859,49 29.422.361,06 30.305.031,89 31.214.182,85 
+
+1.7.5.1.50.00.00.00.0000 Transferências de Recursos do Fundo de Manutenção e Desenvolvimento da Educação Básica e de Valorização dos 15.991.984,72 20.375.716,42 27.492.876,62 31.389.155,52 28.523.859,49 29.422.361,06 30.305.031,89 31.214.182,85 
+
+1.7.5.1.50.01.00.00.0000 Transferências de Recursos do Fundo de Manutenção e Desenvolvimento da Educação Básica e de Valorização dos 15.991.984,72 20.375.716,42 27.492.876,62 31.389.155,52 28.523.859,49 29.422.361,06 30.305.031,89 31.214.182,85 
+
+1.7.5.1.50.01.01.00.0000 Transferências de Recursos do Fundo de Manutenção e Desenvolvimento da Educação Básica e de Valorização do 15.991.984,72 20.375.716,42 27.492.876,62 31.389.155,52 28.523.859,49 29.422.361,06 30.305.031,89 31.214.182,85 
+
+1.7.5.8.00.00.00.00.0000 Transferências de Outras Instituições Públicas – Específica E/M 41.224.487,63 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.7.5.8.99.00.00.00.0000 Outras Transferências Multigovernamentais 41.224.487,63 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.7.5.8.99.01.00.00.0000 Outras Transferências Multigovernamentais 41.224.487,63 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.7.5.8.99.01.99.00.0000 FUNDEF – Precatórios 41.224.487,63 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+1.9.0.0.00.00.00.00.0000 Outras Receitas Correntes 1.817.838,60 970.554,53 741.918,82 1.035.181,43 347.549,09 793.987,62 817.807,26 842.341,46 
+
+1.9.1.0.00.00.00.00.0000 Multas Administrativas, Contratuais e Judiciais 174.005,44 163.129,05 484.040,18 258.419,07 80.000,00 518.010,73 533.551,05 549.557,58 
+
+1.9.1.1.00.00.00.00.0000 Multas Administrativas, Contratuais e Judiciais 174.005,44 163.129,05 484.040,18 258.419,07 80.000,00 518.010,73 533.551,05 549.557,58 
+
+1.9.1.1.01.00.00.00.0000 Multas Previstas em Legislação Específica 169.760,53 163.129,05 0,00 138.419,07 0,00 0,00 0,00 0,00 
+
+1.9.1.1.01.01.00.00.0000 Multas Previstas em Legislação Específica 169.760,53 163.129,05 0,00 138.419,07 0,00 0,00 0,00 0,00 
+
+1.9.1.1.01.01.01.00.0000 Multas Previstas em Legislação Específica 169.760,53 163.129,05 0,00 138.419,07 0,00 0,00 0,00 0,00 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     42 
+ 
+
+1.9.1.1.09.00.00.00.0000 Multas e Juros Previstos em Contratos 4.244,91 0,00 484.040,18 120.000,00 80.000,00 518.010,73 533.551,05 549.557,58 
+
+1.9.1.1.09.01.00.00.0000 Multas e Juros Previstos em Contratos 4.244,91 0,00 484.040,18 120.000,00 80.000,00 518.010,73 533.551,05 549.557,58 
+
+1.9.1.1.09.01.01.00.0000 Multas e Juros Previstos em Contratos 4.244,91 0,00 484.040,18 120.000,00 80.000,00 518.010,73 533.551,05 549.557,58 
+
+1.9.2.0.00.00.00.00.0000 Indenizações, Restituições e Ressarcimentos 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.2.2.00.00.00.00.0000 Restituições 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.2.2.99.00.00.00.0000 Outras Restituições 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.2.2.99.01.00.00.0000 Outras Restituições 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.2.2.99.01.01.00.0000 Outras Restituições – Principal 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.2.2.99.01.01.99.0000 Outras Restituições 1.389.746,95 360.489,99 170.403,69 612.893,39 176.793,83 182.362,84 187.833,73 193.468,74 
+
+1.9.9.0.00.00.00.00.0000 Demais Receitas Correntes 254.086,21 446.935,49 87.474,95 163.868,97 90.755,26 93.614,05 96.422,47 99.315,14 
+
+1.9.9.0.99.00.00.00.0000 Outras Receitas 254.086,21 446.935,49 87.474,95 163.868,97 90.755,26 93.614,05 96.422,47 99.315,14 
+
+1.9.9.0.99.99.00.00.0000 OUTRAS RECEITAS DIVERSAS 254.086,21 446.935,49 87.474,95 163.868,97 90.755,26 93.614,05 96.422,47 99.315,14 
+
+2.0.0.0.00.00.00.00.0000 Receitas de Capital 703.130,66 511.178,34 6.317.402,51 1.444.466,33 10.294.822,41 6.760.765,71 6.963.588,69 7.172.496,36 
+
+2.2.0.0.00.00.00.00.0000 Alienação de Bens 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.2.1.0.00.00.00.00.0000 Alienação de Bens Móveis 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.2.1.3.00.00.00.00.0000 Alienação de Bens Móveis e Semoventes 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.2.1.3.00.01.00.00.0000 Alienação de Bens Móveis e Semoventes 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.2.1.3.00.01.01.00.0000 Alienação de Bens Móveis e Semoventes – Principal 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.2.1.3.00.01.01.01.0000 ALIENAÇÃO DE BENS MÓVEIS ADQUIRIDOS COM RECURSOS NÃO VINCULADOS 47.800,00 0,00 0,00 18.134,96 0,00 0,00 0,00 0,00 
+
+2.4.0.0.00.00.00.00.0000 Transferências de Capital 655.330,66 511.178,34 6.317.402,51 1.426.331,37 10.294.822,41 6.760.765,71 6.963.588,69 7.172.496,36 
+
+2.4.1.0.00.00.00.00.0000 Transferências da União e de Suas Entidades 590.980,66 491.570,00 6.177.676,40 1.426.331,37 10.149.856,57 6.611.233,45 6.809.570,46 7.013.857,58 
+
+2.4.1.1.00.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde - SUS 196.370,00 306.320,00 2.272.500,00 0,00 2.357.718,75 2.431.986,89 2.504.946,50 2.580.094,90 
+
+2.4.1.1.51.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS – Fundo a Fundo – Bloco de Estruturação da rede de 196.370,00 306.320,00 2.272.500,00 0,00 2.357.718,75 2.431.986,89 2.504.946,50 2.580.094,90 
+
+2.4.1.1.51.01.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS – Fundo a Fundo – Bloco de Estruturação da rede de 196.370,00 306.320,00 2.272.500,00 0,00 2.357.718,75 2.431.986,89 2.504.946,50 2.580.094,90 
+
+  
+
+Código Especificação 
+Receitas Realizadas Previsão Estimativa da Receita 
+
+2019 2020 2021 2022 2023 2024 2025 2026 
+
+2.4.1.2.00.00.00.00.0000 Transferências de Recursos do Fundo Nacional do Desenvolvimento da Educação – FNDE 0,00 0,00 245.346,58 0,00 254.547,08 262.565,31 270.442,27 278.555,54 
+
+2.4.1.2.50.00.00.00.0000 Transferências de Recursos Destinados a Programas de Educação 0,00 0,00 245.346,58 0,00 254.547,08 262.565,31 270.442,27 278.555,54 
+
+2.4.1.2.50.09.00.00.0000 Outras Transferências destinadas a Programas de Educação 0,00 0,00 245.346,58 0,00 254.547,08 262.565,31 270.442,27 278.555,54 
+
+2.4.1.4.00.00.00.00.0000 Transferências de Convênios da União e de Suas Entidades 394.610,66 185.250,00 3.659.829,82 1.426.331,37 7.537.590,74 3.916.681,25 4.034.181,69 4.155.207,14 
+
+2.4.1.4.50.00.00.00.0000 Transferências de Convênios da União para o Sistema Único de Saúde - SUS 0,00 0,00 0,00 808.434,12 717.920,49 0,00 0,00 0,00 
+
+2.4.1.4.50.01.00.00.0000 Transferências de Convênios da União para o Sistema Único de Saúde – SUS 0,00 0,00 0,00 808.434,12 717.920,49 0,00 0,00 0,00 
+
+2.4.1.4.50.01.01.00.0000 Transferências de Convênios da União para o Sistema Único de Saúde – SUS 0,00 0,00 0,00 808.434,12 717.920,49 0,00 0,00 0,00 
+
+2.4.1.4.51.00.00.00.0000 Transferências de Convênios da União Destinadas a Programas de Educação 0,00 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+2.4.1.4.51.01.00.00.0000 Transferências de Convênios da União Destinadas a Programas de Educação 0,00 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+2.4.1.4.51.01.01.00.0000 Transferências de Convênios da União Destinadas a Programas de Educação 0,00 0,00 0,00 0,00 0,00 0,00 0,00 0,00 
+
+2.4.1.4.99.00.00.00.0000 Outras Transferências de Convênios da União e de Suas Entidades 394.610,66 185.250,00 3.659.829,82 517.897,25 6.819.670,25 3.916.618,25 4.034.181,69 4.155.207,14 
+
+2.4.1.4.99.01.00.00.0000 Outras Transferências de Convênios da União e de Suas Entidades 394.610,66 185.250,00 3.659.829,82 517.897,25 6.819.670,25 3.916.618,25 4.034.181,69 4.155.207,14 
+
+2.4.1.4.99.01.01.00.0000 Outras Transferências de Convênios da União e de Suas Entidades 394.610,66 185.250,00 3.659.829,82 517.897,25 6.819.670,25 3.916.618,25 4.034.181,69 4.155.207,14 
+
+2.4.2.0.00.00.00.00.0000 Transferências dos Estados e do Distrito Federal e de suas Entidades 64.350,00 19.608,34 139.726,11 0,00 144.965,84 149.532,26 154.018,23 158.638,78 
+
+2.4.2.4.00.00.00.00.0000 Transferências dos Estados e do Distrito Federal e de suas Entidades 64.350,00 19.608,34 139.726,11 0,00 144.965,84 149.532,26 154.018,23 158.638,78 
+
+2.4.2.1.00.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS dos Estados e DF 64.350,00 19.608,34 139.726,11 0,00 144.965,84 149.532,26 154.018,23 158.638,78 
+
+2.4.2.1.50.00.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 64.350,00 19.608,34 139.726,11 0,00 144.965,84 149.532,26 154.018,23 158.638,78 
+
+2.4.2.1.50.01.00.00.0000 Transferências de Recursos do Sistema Único de Saúde – SUS 64.350,00 19.608,34 139.726,11 0,00 144.965,84 149.532,26 154.018,23 158.638,78 
+
+7.0.0.0.00.00.00.00.0000 Receitas Correntes Intra-orçamentárias 3.996.427,29 4.441.982,43 5.777.030,06 9.307.072,00 9.549.672,00 9.182.469,25 9.367.943,34 9.558.981,64 
+
+7.2.0.0.00.00.00.00.0000 Receita de Contribuições Intra-orçamentárias 3.996.427,29 4.441.982,43 5.777.030,06 9.307.072,00 9.549.672,00 9.182.469,25 9.367.943,34 9.558.981,64 
+
+7.2.1.0.00.00.00.00.0000 Receita de Contribuições Sociais Intra-orçamentária 3.996.427,29 4.441.982,43 5.777.030,06 9.307.072,00 9.549.672,00 9.182.469,25 9.367.943,34 9.558.981,64 
+
+7.2.1.5.00.00.00.00.0000 Contribuições para Regimes Próprios de Previdência e Sistema de Proteção Social – Intra 3.996.427,29 4.441.982,43 5.777.030,06 9.307.072,00 9.549.672,00 9.182.469,25 9.367.943,34 9.558.981,64 
+
+7.2.1.5.02.00.00.00.0000 Contribuição Patronal – Servidor Civil - Intra 2.966.528,76 3.932.342,96 4.844.855,71 8.343.205,00 8.585.805,00 8.184.873,74 8.340.419,96 8.500.632,56 
+
+7.2.1.5.02.01.00.00.0000 Contribuição Patronal – Servidor Civil – Intra 2.483.999,73 3.287.866,13 3.701.748,19 4.348.250,00 4.474.687,00 3.961.541,51 4.080.387,76 4.202.799,39 
+
+7.2.1.5.02.01.01.00.0000 Contribuição Patronal – Servidor Civil – Intra 2.483.999,73 3.287.866,13 3.701.748,19 4.348.250,00 4.474.687,00 3.961.541,51 4.080.387,76 4.202.799,39 
+
+7.2.1.5.02.02.00.00.0000 Contribuição Previdenciária para Amortização de Déficit Atuarial – Taxa Suplementar 482.529,03 644.476,85 1.143.107,52 3.994.955,00 4.111.118,00 4.223.332,23 4.260.032,20 4.297.833,17 
+
+7.2.1.5.02.02.01.00.0000 Contribuição Previdenciária para Amortização de Déficit Atuarial – Taxa Suplementar 482.529,03 644.476,85 1.143.107,52 3.994.955,00 4.111.118,00 4.223.332,23 4.260.032,20 4.297.833,17 
+
+7.2.1.5.51.00.00.00.0000 Contribuição Patronal – Parcelamento 1.029.898,53 509.639,45 932.174,35 963.867,00 963.867,00 997.596,51 1.027.523,38 1.058.349,08 
+
+7.2.1.5.51.01.00.00.0000 Contribuição Patronal – Servidor Civil Ativo - Parcelamentos 1.029.898,53 509.639,45 932.174,35 963.867,00 963.867,00 997.596,51 1.027.523,38 1.058.349,08 
+
+7.2.1.5.51.01.01.00.0000 Contribuição Patronal – Servidor Civil Ativo – Parcelamentos 1.029.898,53 509.639,45 932.174,35 963.867,00 963.867,00 997.596,51 1.027.523,38 1.058.349,08 
+
+Fonte: TC Contabilidade Pública, Divisão de Contabilidade/SMf, 30/mar/2022 às 10h e 23m Total: 141.962.978,01 116.802.441,35 158.163.581,53 136.974.579,78 171.548.450,70 172.263.699,39 177.341.610,40 182.571.858,73 
+
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     43 
+ 
+
+ANEXO DE METAS FISCAIS 
+I.a – METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS PRINCIPAIS FONTES DE RECEITA 
+2023 
+  
+Receita Industrial 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 16.234.703,50 ------ 
+
+2021 25.446.948,60 36.20 % 
+
+2022 18.704.375,83 (36,05) % 
+
+2023 26.401.209,16 29,15 % 
+
+2024 27.232.847,25 3,15 % 
+
+2025 28.049.832,66 3,00 % 
+
+  
+Receita de Serviços 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 6.988.828,29 ------ 
+
+2021 8.524.759,00 18,02 % 
+
+2022 6.880.262,65 (23,90) % 
+
+2023 8.835.965,98 22,13 % 
+
+2024 9.123.037,24 3,25 % 
+
+2025 9.396.728,36 3,00 % 
+
+  
+Transferências Correntes 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 229.574,42 ------ 
+
+2021 1.034.929,77 77,82 % 
+
+2022 299.638,78 (245,39) % 
+
+2023 1.101.056,25 72,79 % 
+
+2024 1.107.562,42 0,59 % 
+
+2025 1.140.789,28 3,00 % 
+
+  
+Outras Receitas Correntes 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 % 
+
+2022 0,00 0,00 % 
+
+2023 0,00 0,00 % 
+
+2024 0,00 0,00 % 
+
+2025 0,00 0,00 % 
+
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+I.a – METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS PRINCIPAIS FONTES DE RECEITA 
+2023 
+  
+Impostos, Taxas e Contribuições de Melhoria 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 % 
+
+2022 0,00 0,00 % 
+
+2023 0,00 0,00 % 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     44 
+ 
+
+2024 0,00 0,00 % 
+
+2025 0,00 0,00 % 
+
+  
+Contribuições 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 1.810.002,49 ------ 
+
+2021 2.531.426,94 28,50 % 
+
+2022 2.089.234,73 (21,17) % 
+
+2023 2.626.355,45 20,45 % 
+
+2024 2.709.085,65 3,15 % 
+
+2025 2.790.358,21 3,00 % 
+
+  
+Receita Patrimonial 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 85.615.617,35 ------ 
+
+2021 107.789.165,83 20,57 % 
+
+2022 97.214.348,03 (10,88) 
+
+2023 112.391.820,36 13,50 
+
+2024 115.353.944,25 2,64 
+
+2025 118.814.562,61 3,00 
+
+  
+Receita Agropecuária 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 970.554,53 ------ 
+
+2021 741.918,82 (30,82) 
+
+2022 1.035.181,43 28,33 
+
+2023 347.549,09 (197,85) 
+
+2024 793.987,62 128,45 
+
+2025 817.807,25 3,00 
+
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+I.a – METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS PRINCIPAIS FONTES DE RECEITA 
+2023 
+  
+Operações de Crédito 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 % 
+
+2022 0,00 0,00 % 
+
+2023 0,00 0,00 % 
+
+2024 0,00 0,00 % 
+
+2025 0,00 0,00 % 
+
+  
+Alienação de Bens 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 % 
+
+2022 18.134,96 100,00 % 
+
+2023 0,00 0,00 % 
+
+2024 0,00 0,00 % 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     45 
+ 
+
+2025 0,00 0,00 % 
+
+  
+Amortização de Empréstimos 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 % 
+
+2022 0,00 0,00 % 
+
+2023 0,00 0,00 % 
+
+2024 0,00 0,00 % 
+
+2025 0,00 0,00 % 
+
+  
+Transferências de Capital 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 511.178,34 ------ 
+
+2021 6.317.402,51 91,91 % 
+
+2022 1.426.331,37 (342,91) % 
+
+2023 10.294.822,41 86,15 % 
+
+2024 6.760.765,71 (34,33) % 
+
+2025 6.963.588,69 3,00 % 
+
+  
+Receitas Correntes Intra-Orçamentária 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 4.441.982,43 ------ 
+
+2021 5.777.030,06 23,11 % 
+
+2022 9.307.072,00 37,93 % 
+
+2023 9.549.672,00 2,54 % 
+
+2024 9.182.469,25 (3,85) % 
+
+2025 9.367.943,34 2,02 % 
+
+  
+Fonte: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 30/mar/2022 às 19h e 10m 
+  
+FERNANDO SÉRGIO LIRA NETO 
+Prefeito 
+190.583.144-72 
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS METAS ANUAIS II – DESPESAS 
+2023 
+
+  
+  
+
+CATEGORIA ECONÔMICA E GRUPOS DE NATUREZA DE DESPESA 
+R$ 
+
+2023 2024 2025 
+
+DESPESAS CORRENTES (I) 145.740.027,99 152.077.739,02 156.640.071,21 
+
+Pessoal e Encargos Sociais 86.753.345,17 89.486.075,54 93.839.745,33 
+
+Juros e Encargos de Dívida 254.171,76 262.178,17 270.043,52 
+
+Outras Despesas Correntes 58.732.511,06 60.329.485,31 62.530.282,36 
+
+DESPESAS DE CAPITAL (II) 22.659.593,67 18.408.398,58 16.810.650,59 
+
+Investimentos 17.730.496,38 13.376.822,87 11.688.127,60 
+
+Inversões Financeiras 114.866,89 118.485,20 122.039,76 
+
+Amortização Financeira 4.814.230,40 4.913.090,51 5.000.483,23 
+
+RESERVA DE CONTINGÊNCIA (III) 3.148.829,04 3.777.561,79 3.890.888,60 
+
+TOTAL (IV) = (I + II + III) 171.548.450,70 172.263.699,39 177.341.610,40 
+
+  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     46 
+ 
+
+FONTE: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 30/mar/2022, 19h e 15m 
+  
+FERNANDO SÉRGIO LIRA NETO 
+Prefeito 
+190.583.144-72 
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+II.a – METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS PRINCIPAIS DESPESAS 
+2023 
+  
+PESSOAL E ENCARGOS SOCIAIS 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 60.963.326,46 ------ 
+
+2021 76.510.837,05 25,50 % 
+
+2022 86.753.345,17 13,39 % 
+
+2023 89.486.075,54 3,15 % 
+
+2024 93.839.745,33 4,86 % 
+
+2025 96.654.937,69 3,00 % 
+
+  
+JUROS E ENCARGOS DA DÍVIDA 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 26.354,04 ------ 
+
+2021 55.097,07 9,60 % 
+
+2022 254.171,76 61,32 % 
+
+2023 262.178,17 3,15 % 
+
+2024 270.043,52 3,00 % 
+
+2025 278.144,82 3,00 % 
+
+  
+OUTRAS DESPESAS CORRENTES 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 46.416.352,05 ------ 
+
+2021 51.336.339,65 0,60 % 
+
+2022 58.732.511,06 14,41 % 
+
+2023 60.329.485,31 2,72 % 
+
+2024 62.530.282,36 3,65 % 
+
+2025 64.406.190,83 3,00 % 
+
+  
+INVESTIMENTOS 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 18.027.360,67 ------ 
+
+2021 4.599.103,11 (74,49) % 
+
+2022 17.730.496,38 285,52 % 
+
+2023 13.376.822,87 (24,55) % 
+
+2024 11.688.127,60 12,62 % 
+
+2025 12.038.771,42 3,00 % 
+
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+II.a – METODOLOGIA E MEMÓRIA DE CÁLCULOS DAS PRINCIPAIS DESPESAS 
+2023  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     47 
+ 
+
+INVERSÕES FINANCEIRAS 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 0,00 ------ 
+
+2021 0,00 0,00 
+
+2022 114.866,89 100,00 
+
+2023 118.485,20 3,15 
+
+2024 122.039,76 3,00 
+
+2025 125.700,95 3,00 
+
+  
+AMORTIZAÇÃO/REFINANCIAMENTO DA DÍVIDA 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 1.758.546,64 ------ 
+
+2021 1.733.711,31 (1,41) 
+
+2022 4.814.230,40 177,68 
+
+2023 4.913.090,51 2,05 
+
+2024 5.000.483,23 1,78 
+
+2025 5.150.497,73 3,00 
+
+  
+RESERVA DE CONTINGÊNCIA 
+  
+
+Metas Anuais VALOR NOMINAL – R$ VARIAÇÃO % 
+
+2020 2.793.372,67 ------ 
+
+2021 2.739.491,60 (1,93) % 
+
+2022 3.148.829,04 14,94 % 
+
+2023 3.777.561,79 19,97 % 
+
+2024 3.890.888,64 3,00 % 
+
+2025 4.007.615,30 3,00 % 
+
+  
+FONTE: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 30/mar/2022, 22h e 05m 
+  
+FERNANDO SÉRGIO LIRA NETO 
+Prefeito 
+190.583.144-72 
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+AVALIAÇÃO DO CUMPRIMENTO DAS METAS FISCAIS DO EXERCÍCIO ANTERIOR 
+2023 
+  
+AMF – Demonstrativo 2 (LRF, art. 4º, §2º, Inciso I) R$ 1,00 
+  
+
+  
+ESPECIFICAÇÃO 
+
+  
+Metas Previstas em 2021 
+
+(a) 
+
+  
+% PIB 
+
+  
+% RCL 
+
+  
+Metas Realizadas em 2021 
+
+(b) 
+
+  
+% PIB 
+
+  
+% RCL 
+
+Variação 
+
+Valor 
+(c) = (b-a) 
+
+% 
+(c/a) x 100 
+
+Receita Total 129.985.312,53 10,120% 123,71% 157.094.156,40 11.615% 111,24% 27.108.843,87 20,86% 
+
+Receitas Primárias (I) 129.393.170,73 10,074% 123,14% 150.296.435,34 11,112% 106,43% 20.903.264,61 16,15% 
+
+Despesa Total 129.985.312,53 10,120% 123,71% 152.483.167,55 11,274% 107,98% 22.497.855,02 17,31% 
+
+Despesas Primárias (II) 129.418.152,04 10,076% 123,17% 142.397.984,07 10,528% 100,84% 12.979.832,03 10,03% 
+
+Resultado Primário (III) = (I-II) -24.981,31 -0,002% -0,02% 7.898.451,27 0,584% 5,59% 7.923.432,58 -31717,44% 
+
+Resultado Nominal -297.100,24 -0,023% -0,28% 7.898.451,27 0,584% 5,59% 8.195.551,51 -2758,51% 
+
+Dívida Pública Consolidada 9.460.456,76 0,737% 9,00% 7.799.981,11 0,577% 5,52% -1.660.475,65 -17,55% 
+
+Dívida Consolidada Líquida 7.516.906,40 0,585% 7,15% -56.421.196,75 -4,172% -39,95% -63.938.1036,15 -850,59% 
+
+  
+FONTE: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 25/mar/2022, 15h e 11m  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     48 
+ 
+
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+METAS FISCAIS ATUAIS COMPARADAS COM AS FIXADAS NOS TRÊS EXERCÍCIOS ANTERIORES 
+2023 
+  
+TABELA 3 – LRF – art. 4º - § 2º - Inciso II R$ 1,00 
+  
+  
+ESPECIFICAÇÃO 
+
+VALORES A PREÇOS CORRENTES 
+
+2020 2021 % 2022 % 2023 % 2024 % 2025 % 
+
+Receita Total 86.167.256,33 129.985.312,53 50,85 136.974.579,78 5,38 171.548.450,70 25,24 172.263.699,39 0,416937 117.341.610,40 2,95 
+
+Receitas Primárias (I) 89.182.996,64 129.271.049,71 44,95 136.614.335,50 5,68 157.932.289,39 15,60 158.470.594,45 0,340845 163.224.712,32 3,00 
+
+Despesa Total 86.167.256,33 129.985.312,53 50,85 136.974.579,78 5,38 173.232.187,47 26,47 173.878.127,70 0,37 178.950.263,96 2,92 
+
+Despesas Primárias (II) 76.420.275,31 128.200.411,85 67,76 135.185.771,41 5,45 157.567.104,36 16,56 159.338.337,19 1,12 161.984.279,75 1,66 
+
+Resultado Primário (III) = (I-II) 12.762.721,33 1.070.637,86 -91,61 1.428.564,09 33,43 365.185,03 -74,44 867.742,74 -337,62 1,240.432,57 -242,95 
+
+Resultado Nominal 43.591.517,95 1.816.986,58 -104,17 -2.538.664,55 39,72 111.013,27 -104,37 -1.129.920,91 -1117,83 970.389,05 -185,88 
+
+Dívida Pública Consolidada 10.006.044,02 6.793.003,30 -32,11 4.937.289,05 -27,32 7.054.125,93 42,87 6.376.929,84 -9,6 5.764.744,58 -9,60 
+
+Dívida Consolidada Líquida 7.814.006,64 34.067.234,98 -535,98 -36.563.833,99 7,33 -48.985.338,60 33,97 -53.829.945,25 9,89 -53.521.872,62 -0,57 
+
+  
+R$ 1,00 
+  
+  
+ESPECIFICAÇÃO 
+
+VALORES A PREÇOS CONSTANTES 
+
+2020 2021 % 2022 % 2023 % 2024 % 2025 % 
+
+Receita Total 92.328.215,16 134.534.798,47 45,71 136.974.579,78 1,81 165.347.904,29 20,71 160.979.066,81 -2,64 160.883.253,56 -0,06 
+
+Receitas Primárias (I) 95.559.580,90 133.795.536,45 40,01 136.614.335,50 2,11 152.223.893,39 11,43 148.089.519,16 -2,72 148.076.487,63 -0,01 
+
+Despesa Total 92.328.215,16 134.534.798,47 45,71 136.974.579,78 1,81 166.970.783,10 21,90 162.487.737,31 -2,68 162.351.686,44 -0,08 
+
+Despesas Primárias (II) 81.884.324,99 132.687.426,26 62,04 135.185.771,41 1,88 151.871.907,82 12,34 184.900.417,90 -1,96 146.951.174,59 -1,31 
+
+Resultado Primário (III) = (I-II) 13.675.255,91 1.108.110,19 -91,90 1.428.564,09 28,92 351.985,57 -75,36 810.898,74 -330,38 1.125.315,05 -238,77 
+
+Resultado Nominal 46.708.311,48 1.880.581,11 -104,03 -2.538.664,55 34,99 107.000,74 -104,21 -1.055.902,17 -1086,82 880.331,17 -183,37 
+
+Dívida Pública Consolidada 10.721.476,17 7.030.758,42 -34,42 4.937.289,05 -29,78 6.799.157,52 37,71 5.959.190,58 -12,35 5.229.741,98 -12,24 
+
+Dívida Consolidada Líquida 8.372.708,11 35.259.588,20 -521,13 -36.563.833,99 3,70 -47.214.784,19 29,13 -50.303.658,77 6,54 -48.554.724,32 -3,48 
+
+  
+FONTE: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 28/mar/2022, 18h e 11m 
+Nota: O cálculo das metas foi realizado considerando-se o seguinte cenário macroeconômico 
+IPCA – Índice Nacional de Preços ao Consumidor Amplo acumulado, estimado com base nos indicativos do Banco Central do Brasil 
+  
+
+Índices do IPCA medidos pelo Banco Central 
+
+2020 4,5173 1,0715 
+
+2021 3,5300 1,0350 
+
+2022 3,5000 0,0000 
+
+2023 3,7500 1,0375 
+
+2024 3,1500 1,0701 
+
+2025 3,0000 1,1023 
+
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+EVOLUÇÃO DO PATRIMÔNIO LÍQUIDO 
+2023 
+  
+AMF – Demonstrativo 4 (LRF, art. 4º, § 2º, Inciso III) R$ 1,00 
+  
+
+PATRIMÔNIO LÍQUIDO 2021 % 2020 % 2019 % 
+
+Patrimônio/Capital (144.722.580,84) 137,00% (138.290.262,52) 95,56% (121.360.243,34) 87,76% 
+
+Reservas 0,00 0,00% 0,00 0,00% 0,00 0,00% 
+
+Resultado Acumulado 39.301.288,14 -37,00% (6.432.318,32) 4,44% (16.930.019,18) 12,24% 
+
+Total (105.421.292,70) 100,00% (144.722.580,84) 100,00% (138.290.262,52) 100,00% 
+
+  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     49 
+ 
+
+REGIME PREVIDENCIÁRIO 
+
+PATRIMÔNIO LÍQUIDO 2021 % 2020 % 2019 % 
+
+Patrimônio/Capital (122.268.407,91) 0,00% (143.488.001,54) 117,35% (136.586.300,32) 95,19% 
+
+Reservas 0,00 0,00% 0,00 0,00 0,00 0,00% 
+
+Resultado Acumulado 0,00 0,00% 21.219.593,63 -17,35% (6.901.701,22) 4,81% 
+
+Total (122.268.407,91) 0,00% (122.268.407,91) 100,00% (143.488.001,54) 100,00% 
+
+  
+FONTE: TC Contabilidade Pública, Divisão de Contabilidade/SMF, 28/mar/2022, 22h e 15m 
+Nota: A evolução negativa dos PLs se deu devido a Provisão Matemática Previdenciária. Revisão dos lançamentos serão efetuados para os devidos ajustes. 
+  
+LEI DE DIRETRIZES ORÇAMENTARIAS 
+ANEXO DE METAS FISCAIS 
+ORIGEM E APLICAÇÃO DOS RECURSOS OBTIDOS COM A ALIENAÇÃO DE ATIVOS 
+2023 
+  
+AMF DEMOSTRATIVO 5 (LRF, ART 4º, §2º, INC III       
+
+RECEITAS REALIZADAS 2021 (a) 2020 (b) 2019 (c) 
+
+RECEITA DE CAPITAL ALIENAÇÃO DE ATIVOS (1) 0,00 0,00 47.800,00 
+
+Alienação de Bens Moveis 0,00 0,00 47.800,00 
+
+Alienação de Bens imóveis 0,00 0,00 0,00 
+
+Alienação de bens Intangíveis 0,00 0,00 0,00 
+
+Rendimentos de Aplicação financeira 0,00 0,00 0,00 
+
+DESPESAS EXECUTADAS 2021 (d) 2020 (e) 2019 (f) 
+
+APLICAÇÃO DOS RECURSOS DE ALIENAÇÃO DE ATIVOS ( II ) 0,00 0,00 47.800,00 
+
+Despesas de capital 0,00 0,00 47.800,00 
+
+Investimentos 0,00 0,00 47.800,00 
+
+Inversões financeiras 0,00 0,00 0,00 
+
+Amortização de divida 0,00 0,00 0,00 
+
+DESPESAS CORRENTES DOS REGIMES DE PREVIDENCIA 0,00 0,00 0,00 
+
+Regime Geral de previdência social 0,00 0,00 0,00 
+
+Regime próprio de previdência dos servidores 0,00 0,00 0,00 
+
+SALDO FINANCEIRO 
+2020 
+
+(g)=((Ia-IId ) + IIIb) 
+2019 
+
+(h)=((IB-IIe+IIII ) 
+2018 
+
+(I)=(Ic-III ) 
+
+VALOR (III) 0,00 0,00 0,00 
+
+Fonte :TC Contabilidade pública, divisão de contabilidade / SMF ,28 /mar/2022 22h e 35m 
+
+  
+AVALIAÇÃO DA SITUAÇÃO FINANCEIRA E ATUARIAL DO RPPS 
+  
+
+RECEITAS E DESPESAS PREVIDENCIARIAS DP REGIME PROPRIO DE PREVIDENCIA DOS SERVIDORES 
+
+PLANO PREVIDENCIARIO  
+
+RECEITAS PREVIDENCIARIAS  2019 2020 2021 
+
+RECEITA DE CONTRIBUINTES ( I ) 7.672.086,91 7.518.688,27 8.932.698,64 
+
+Civil 3.131.890,12 3.554,310.73 3.796.579,30 
+
+Ativo 3.131.890,12 3.554,310.73 3.796.579,30 
+
+Inativo 3.109.025,30 3.530.650,31 3.781.997,57 
+
+Pensionista 22.864,82 21.642,56 14.581,73 
+
+Militar   2.017,86   
+
+Ativo       
+
+Inativo       
+
+Pensionista       
+
+Receitas de contribuições patronais 4.350,189,18 3.780.940,06 4.619.683,77 
+
+Civil 4.350,189,18 3.780.940,06 4.619.683,77 
+
+Ativo 4.350,189,18 3.780.940,06 4.619.683,77 
+
+Inativo       
+
+Pensionista       
+
+Militar       
+
+Ativo       
+
+Inativo       
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     50 
+ 
+
+Pensionista       
+
+Receitas patrimonial 675.83 3.742,91 18.156,62 
+
+Receitas Imobiliária       
+
+Receitas de valores Mobiliários 675.83 3.742,91 18.156,62 
+
+Outras receitas patrimoniais       
+
+Receitas de serviços       
+
+Outras receitas correntes 189.331,78 179.694,57 498.278,95 
+
+Compensação previdenciárias RGPS Para RPPS       
+
+Aportes periódicas para amortização de difícil aruarial do RPPS (II) ²       
+
+Demais receitas correntes 189.331,78 179.694,57 498.278,95 
+
+RECEITA DO CAPITAL ( III )        
+
+Alienação de bens       
+
+Amortização de empréstimos       
+
+Outras receitas de capital       
+
+TOTAL DAS RECEITAS PREVIDENCIARIAS – ( IV ) = ( I + III – II 7.672.086,91 7518.688.27 8.932.698,64 
+
+DESPESAS PREVIDENCIARIAS RPPS 2019 2020 2021 
+
+Benefício - civil 7.913.309,05 8.314.351,45 9.025.258,41 
+
+Aposentadoria 6.968.667,44 7.217.582,04 7.747.645,65 
+
+Pensões 944.641,44 1.089.566,87 1.277.612,76 
+
+Outros benefícios previdenciários   7.202,52   
+
+Benefícios - Militar       
+
+Reformas       
+
+Pensões       
+
+Outros benefícios previdenciários       
+
+Outras despesas previdenciárias       
+
+Compensação previdenciárias RGPS Para RPPS       
+
+Demais despesas previdenciárias       
+
+TOTAL DAS DESPESAS PREVIDENCIÁRIAS RPPS ( V ) 7.913.309,05 8.314.551,43 9.025.258,41 
+
+RESULTADO PREVIDENCIARIO IV = (IV -V) ² 241.222,14 795.663,16 92.559,77 
+
+RECURSOS RPPS ARRECADADOS EM EXERCICIOS ANTERIORES 2019 2020 2021 
+
+VALOR       
+
+RESERVA ORÇAMENTARIA RPPS 2019 2020 2021 
+
+VALOR 489.967,40 22.548,21 2.195.630,91 
+
+APORTES DE RECURSOS PARA PLANOS PREVIDENCIARIOS RPPS 2019 2020 2021 
+
+Planos de amortização contribuição patronal suplementar 
+
+672.901.55 644.476,85 1.143.107,52 
+Plano de amortização aporte periódico de valores predefinidos 
+
+Outros aportes RPPS 
+
+Recursos para cobertura de défices financeiros 
+
+BENS DE DIREITOS RPPS 2019 2020 2021 
+
+Caixa de equivalentes de caixa 
+
+  
+411.296,91 
+
+  
+280.395,51 
+
+  
+496.387,98 
+
+Investimento e aplicações 
+
+Outros bens de direitos 
+
+  
+
+  
+Plano Financeiro 
+
+  
+RECEITAS PREVIDENCIÁRIAS - RPPS 2019 2020 2021 
+
+RECEITAS CORRENTES (VII)       
+
+Receita de Contribuições dos Segurados       
+
+Civil       
+
+Ativo       
+
+Inativo       
+
+Pensionista       
+
+Militar       
+
+Ativo       
+
+Inativo       
+
+Pensionista       
+
+Receita de Contribuições Patronais       
+
+Civil       
+
+Ativo       
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     51 
+ 
+
+Inativo       
+
+Pensionista       
+
+Militar       
+
+Ativo       
+
+Inativo       
+
+Pensionista       
+
+Receita Patrimonial       
+
+Receitas Imobiliárias       
+
+Receitas de Valores Mobiliários       
+
+Outras Receitas Patrimoniais       
+
+Receita de Serviços       
+
+Outras Receitas Correntes       
+
+Compensação Previdenciária do RGPS para o RPPS       
+
+Demais Receitas Correntes       
+
+RECEITAS DE CAPITAL (VIII)       
+
+Alienação de Bens, Direitos e Ativos       
+
+Amortização de Empréstimos       
+
+Outras Receitas de Capital       
+
+TOTAL DAS RECEITAS PREVIDENCIÁRIAS RPPS – (IX) = (VII + VIII)       
+
+  
+DESPESAS PREVIDENCIÁRIAS - RPPS 2019 2020 2021 
+
+Benefícios – Civil       
+
+Aposentadorias       
+
+Pensões       
+
+Outros Benefícios Previdenciários       
+
+Benefícios – Militar       
+
+Reformas       
+
+Pensões       
+
+Outros Benefícios Previdenciários       
+
+Outras Despesas Previdenciárias       
+
+Compensação Previdenciária do RPPS para o RGPS       
+
+Demais Despesas Previdenciárias       
+
+TOTAL DE DESPESAS PREVIDENCIÁRIAS RPPS (X)       
+
+RESULTADO PREVIDENCIÁRIO (XI) = (IX – X)²       
+
+APORTES DE RECURSOS PARA O PLANO FINANCEIRO DO RRPS 2019 2020 2021 
+
+Recursos para Cobertura de Insuficiências Financeiras       
+
+Recursos para Formação de Reserva       
+
+RECEITAS DA ADMINISTRAÇÃO - RPPS 2019 2020 2021 
+
+RECEITAS CORRENTES 274.827,91 253.825,43 366.024,79 
+
+TOTAL DAS RECEITAS DA ADMINISTRAÇÃO RPPS – (XII) 274.827,91 253.825,43 366.024,79 
+
+DESPESAS ADMINISTRAÇÃO - RPPS 2019 2020 2021 
+
+DESPESAS CORRENTES (XIII) 264.842,95 255.824,85 338.238,57 
+
+DESPESAS DE CAPITAL (XIV) 9.984,96 8.000,58 27.786,22 
+
+TOTAL DAS DESPESAS DA ADMINISTRAÇÃO RPPS (XV) = (XIII + XIV) 274.827,91 253.825,43 366.024,79 
+
+RESULTADO DA ADMINISTRAÇÃO RPPS (XVI) = (XII – XV) - - - 
+
+  
+PROJEÇÃO ATUARIAL DO REGIME PRÓPRIO DE PREVIDÊNCIA DOS SERVIDORES 
+
+PLANO PREVIDENCIÁRIO 
+
+  
+EXERCÍCIO 
+
+Receitas Previdenciárias 
+(a) 
+
+Despesas Previdenciárias 
+(b) 
+
+Resultado Previdenciárias 
+(c) = (a-b) 
+
+Saldo Financeiro do Exercício 
+(d) = (d Exercício 
+
+2021 25.980.778,98 3.819.174,51 22.161.604,47 41.430.837,37 
+
+2022 26.240.586,77 3.857.366,26 22.383.220,51 63.814.057,88 
+
+2023 26.502.992,64 6.996.790,06 19.506.202,58 83.320.260,46 
+
+2024 26.768.022,56 7.066.757,96 19.701.264,60 103.021.525,06 
+
+2025 27.035.702,79 7.137.425,54 19.898.277,25 122.919.802,31 
+
+2026 27.306.059,82 10.403.608,79 16.902.451,03 139.822.253,34 
+
+2027 27.579.120,42 10.507.664,88 17.071.475,54 156.893.728,88 
+
+2028 27.854.911,62 10.612.721,33 17.242.190,29 174.135.919,17 
+
+2029 28.133.460,74 14.010.463,45 14.122.997,29 188.258.916,46 
+
+2030 28.414.795,34 14.150.568,08 14.264.227,26 202.523.143,72 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     52 
+ 
+
+2031 28.698.943,30 14.292.073,76 14.406.869,54 216.930.013,26 
+
+2032 28.985.932,73 17.826.348,63 11.159.584,10 228.089.597,36 
+
+2033 29.275.792,06 18.004.612,12 11.271.179,94 239.360.777,30 
+
+2034 29.568.549,98 18.184.658,24 11.383.891,74 250.744.669,04 
+
+2035 29.864.235,48 21.863.606,79 8.000.628,69 258.745.297,73 
+
+2036 30.162.877,83 22.082.242,86 8.080.634,97 266.825.932,70 
+
+2037 30.464.506,61 22.303.065,29 8.161.441,32 274.987.374,02 
+
+2038 30.769.151,68 26.126.086,69 4.643.064,99 279.630.439,01 
+
+2039 31.076.843,19 26.387.347,55 4.689.495,64 284.319.934,65 
+
+2040 31.387.611,63 26.651.221,04 4.736.390,59 289.056.325,24 
+
+2041 31.701.487,74 30.626.807,31 1.074.680,43 290.131.005,67 
+
+2042 32.018.502,62 30.933.075,38 1.085.427,24 291.216.432,91 
+
+2043 32.338.687,65 31.242.406,14 1.096.281,51 292.312.714,42 
+
+2044 32.662.074,52 35.376.292,91 -2.714.218,39 289.598.496,03 
+
+2045 32.988.695,27 35.730.055,85 -2.741.360,58 286.857.135,45 
+
+2046 33.318.582,22 36.087.356,40 -2.768.774,18 284.088.361,27 
+
+2047 33.651.768,04 40.385.486,82 -6.733.718,78 277.354.642,49 
+
+2048 33.988.285,72 40.789.341,69 -6.801.055,97 270.553.586,52 
+
+2049 34.328.168,58 41.197.235,11 -6.869.066,53 263.684.519,99 
+
+2050 34.671.450,27 45.665.767,15 -10.994.316,88 252.690.203,11 
+
+2051 35.018.164,77 46.122.424,82 -11.104.260,05 241.585.943,06 
+
+2052 35.368.346,42 - 35.368.346,42 276.954.289,48 
+
+2053 35.722.029,88 46.583.649,07 -10.861.619,18 266.092.670,30 
+
+2054 36.079.250,18 47.049.485,56 -10.970.235,38 255.122.434,92 
+
+2055 36.440.042,68 47.519.980,41 -11.079.937,73 244.042.497,19 
+
+2056 36.804.443,11 47.995.180,22 -11.079.937,73 232.851.760,08 
+
+2057 37.172.487,54 48.475.132,02 -11.302.644,48 221.549.115,61 
+
+2058 37.544.212,42 48.959.883,34 -11.415.670,92 210.133.444,68 
+
+2059 37.919.654,54 49.449.482,17 -11.529.827,63 198.603.617,05 
+
+2060 38.298.851,09 49.943.977,00 -11.645.125,91 186.958.491,14 
+
+2061 38.681.839,60 50.443.416,77 -11.761.577,17 175.196.913,98 
+
+2062 39.068.657,99 50.947.850,93 -11.879.192,94 163.317.721,04 
+
+2063 39.459.344,57 51.457.329,44 -11.997.984,87 151.319.736,17 
+
+2064 39.853.938,02 51.971.902,74 -12.117.964,72 139.201.771,45 
+
+2065 40.252.477,40 52.491.621,76 -12.239.144.36 126.962.627,09 
+
+2066 40.655.002,17 53.016.537,98 -12.361.535,81 114.601.091,28 
+
+2067 41.061.552,20 53.546.703,36 -12.485.151,17 102.115.940,11 
+
+2068 41.472.167,72 54.082.170,40 -12.610.002,68 89.505.937,43 
+
+2069 41.886.889,40 54.622.992,10 -12.736.102,70 76.769.834,73 
+
+2070 42.305.758,29 55.169.222,02 -12.863.463,73 63.906.371,00 
+
+2071 42.728.815,87 55.720.914,24 -12.992.098,37 50.914.272,63 
+
+2072 43.156.104,03 56.278.123,38 -13.122.019,35 37.792.253,28 
+
+2073 43.587.665,07 56.840.904,62 -13.253.239,55 24.539.013,73 
+
+2074 44.023.541,72 57.409.313,66 -13.385.771,94 11.153.241,79 
+
+2075 44.463.777,14 57.983.406,80 -13.519.629,66 -2.366.387,87 
+
+2076 44.908.414,91 58.563.240,87 -13.654.825,96 -16.021.213,83 
+
+2077 45.357.499,06 59.148.873,28 -13.791.374,22 -29.812.588,05 
+
+2078 45.811.074,05 59.740.362,01 -13.929.287,96 -43.741.876,00 
+
+2079 46.269.184,79 60.337.765,63 -14.068.580,84 -57.810.456,84 
+
+2080 46.731.876,64 60.941.143,29 -14.209.266,65 -72.019.723,49 
+
+2081 47.199.195,41 61.550.554,72 -14.351.359,31 -86.371.082,80 
+
+2082 47.671.187,36 62.166.060,27 -14.494.872,91 -100.865.955,71 
+
+2083 48.147.899,23 62.787.720,87 -14.639.821,64 -115.505.777,35 
+
+2084 48.629.378,23 63.415.598,08 -14.786.219,85 -130.291.997,20 
+
+PLANO FINANCEIRO 
+
+  
+EXERCÍCIO 
+
+  
+Receitas Previdenciárias 
+
+(a) 
+
+  
+Despesas Previdenciárias 
+
+(b) 
+
+  
+Resultado Previdenciárias 
+
+(c) = (a-b) 
+
+Saldo Financeiro do Exercício 
+(d) = (d Exercício 
+
+  
+Fonte: CADPREV Web MPS 29/03/2022 às 16:22 
+Nota: 
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     53 
+ 
+
+1 Projeção atuarial elaborada em 02/08/2021 
+ 
+2 Esse demonstrativo utiliza as seguintes hipóteses: Taxa real de juros 5,30. Crescimento real do salário 1,00; Taxa de inflação de longo prazo 1,87; Saídas por morte 8; Saída por aposentadoria 14; Valor real ao 
+longo tempo dos benefícios 99,16; Valor real ao longo tempo dos salários 99,16; Probabilidade de casados se adotada premissa 95%. 
+  
+LEI DE DIRETRIZES ORÇAMENTÁRIAS 
+ 
+ANEXO DE METAS FISCAIS 
+ 
+ESTIMATIVA E COMPENSAÇÃO DA RENÚNCIA DE RECEITA 
+ 
+2023 
+  
+AMF- Demonstrativo 7 (LFR, art. 4º, § 2º, inciso V) R$ 1,00 
+
+  
+  
+
+TRIBUTO 
+  
+
+MODALIDADE 
+SETORES/ 
+
+PROGRAMAS/ BENEFICIÁRIO 
+RENÚNCIA DE RECEITA PREVISTA   
+
+COMPENSAÇÃO 2022 2023 2024 
+
+              
+
+TOTAL       - 
+
+  
+FONTE: AGILL, SMF, 29/mar/2022, 18h E 43m 
+ 
+Nota: Não houve estimativa de renúncia de receita para o exercício de referência nem posteriores 
+  
+LEI DE DIRETRIZES ORÇAMENTÁRIAS 
+ 
+ANEXO DE METAS FISCAIS 
+ 
+MARGEM DE EXPANSÃO DAS DESPESAS OBRIGATÓRIAS DE CARÁTER CONTINUADO 
+ 
+2023 
+  
+AMF – Demonstrativo 8 (LFR, art. 4º, § 2º, Inciso V) R$1,00 
+
+  
+EVENTOS Valor Previsto para 2022 
+
+Aumento Permanente 0,00 
+
+(-) Transferências Constitucionais 0,00 
+
+(-) Transferências ao FUNDEB 0,00 
+
+Saldo Final do Aumento Permanente de Receita (I) 0,00 
+
+Redução Permanente de Despesa (II) 3.000.000,00 
+
+Margem Bruta (III) = (I + II) 3.000.000,00 
+
+Saldo Utilizado da Margem Bruta (IV) 0,00 
+
+Novas DOCC 0,00 
+
+Novas DOCC geradas por PPP 0,00 
+
+Margem Liquida de expansão de DOCC (V) = (III + IV) 3.000.000,00 
+
+  
+Fonte: TC Contabilidade Pública, SMF, 29/mar/2022, 18h e 51m 
+ 
+Nota: Redução permanente de despesa se dará, caso haja necessidade, pela indicação do 
+ 
+Prefeito, sem prejuízo das obrigações constitucionais. 
+  
+PRIORIDADES E METAS  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     54 
+ 
+
+Programas e Ações e Produtos Metas 2023 
+ 
+0008. Apoio e incentivo a agropecuária  
+1021 Construção de Açudes e viveiros.  
+Famílias atendidas (unidade). 1000  
+1061 Aquisição de maquinas e equipamentos agrícolas 
+Bem adquirido(unidade). 5 
+ 
+0004 Saúde com qualidade acesso a expansão dos serviços.  
+5004 Estruturação da rede de serviços de atenção básica de saúde. 
+Serviços mantidos (porcentagem) 100 
+5007 Construção e /ou ampliação da unidade básica de saúde 
+Obras executadas percentual de execução física 50 
+5012 Construção de polos de academia de saúde 
+Prédio construído (unidade) 1 
+6003 Programa de atenção primaria básica  
+Serviços mantidos (porcentagem) 100 
+2060 Enfrentamento de emergência Covid-19 
+Serviços mantidos (porcentagem) 100 
+6008 Manutenção da atividade da unid. De pronto atendimento  
+Serviços mantidos (porcentagem) 100 
+6014 Manutenção das atividades de farmácia básica  
+Serviços mantidos (porcentagem) 100 
+6017 Manutenção das atividades de vigilância em saúde 
+Serviços mantidos (porcentagem) 100 
+  
+0003 Proteção inclusão e desenvolvimento social 
+  
+6021 Manut. das politicas de igualdade e enfrent. a violência contra as mulheres 
+Serviço de apoio porcentagem 100 
+6027 Manutenção do índice de gestão descentralizada IGD/BF 
+Família atendida (unidade) 6.981 
+6024 Manutenção das atividades do programa criança feliz 
+Serviços Mantidos (porcentagem) 100 
+6032 Manutenção dos programas de benefícios Eventuais 
+Serviços Mantidos (porcentagem). 100 
+2070 Manutenção das ações de apoio ao idoso 
+Serviços Mantidos porcentagem 100 
+  
+Programas e Ações e Produtos Metas 2023 
+ 
+0005 Urbanização para o desenvolvimento  
+  
+1005 Construção do terminal rodoviário 
+Obras executadas parcialmente de execução fiscal 15 
+1022Pavimentação asfálticas e/ou paralelepípedo em ruas e avenidas 
+Obras executadas parcialmente de execução fiscal 100 
+1010 Construção do pavilhão do artesanato 
+Obras executadas parcialmente de execução fiscal 70 
+1015 construção e/ou Ampliação do sistema de saneamento básico 
+Obras executadas parcialmente de execução fiscal 45  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     55 
+ 
+
+0006 Promoção, Difusão e desenvolvimento da cultura do esporte e do laser  
+ 
+2045 Apoio as ativ. Cívicas culturais e tradicionais do município 
+Apoio a mantido (percentual). 100 
+1033 Construção e /ou ampliação da quadra poliesportiva 
+Obras executadas (percentual físico). 50 
+ 
+2044 Programa de apoio ao esporte amador 
+Apoio a mantido (percentual). 100 
+0002 Educação o caminho para o desenvolvimento 
+2014 Manutenção do Programa nacional de alimentação Escolar PNAE 
+Alunos beneficiados (unidade). 5946 
+2036 Programa nacional de apoio ao transporte Escolar PNATE Fundamental 
+Programa mantido (unidade). 1 
+ 
+1016 Construção e/ou Ampliação das creches 
+Obras executadas percentual físico 100 
+1002 Construção e/ou Ampli. das unid. escolares inclusive em tempo integral 
+Obras executadas percentual físico 100 
+2015 Manutenção das atividades do ensino fundamental 
+Alunos Beneficiados (unidade). 6974 
+2035 Manutenção das atividades dos profissionais do ensino fundamental 
+Alunos beneficiados (unidade). 6974 
+ 
+0013 Apoio ao turismo  
+ 
+2008 Manutenção de apoio ao turismo  
+Serviços mantidos (percentual) 
+ 
+0009 Proteção e conservação do meio Ambiente  
+ 
+1052 controle populacional de cães e gatos com aquisição de castro móvel 
+Equipamentos adquiridos (unidade). 1 
+ 
+0010 Seguridade social com responsabilidade 
+ 
+6050 Manutenção do pagamento aos Aposentados e pensionistas e demais benefícios IPREV 
+Inativos atendidos (percentual). 100 
+ 
+0000 Encargos Especiais 
+ 
+0005 Amortização da divida consolidada 
+ 
+Divida reduzida (percentual). 11 
+
+  
+PRIORIDADES E METAS 
+
+  
+Programa, Ações e produtos Meta 2023 
+  
+0001 Manutenção das Ações de Operações Continuadas 
+  
+
+
+
+
+ 
+
+www.diariomunicipal.com.br/ama                                                                                                                                     56 
+ 
+
+2006 Manutenção das Atividades da Superintendência de Transporte e Trânsito – SMTT 
+Atividades mantidas (percentual) 100 
+  
+2001 Manutenção das Atividades da Câmara Municipal 
+Atividades mantidas (percentual) 100 
+  
+2040 Manutenção das Atividades da Guarda Civil Municipal 
+Atividade mantida (percentual) 100 
+  
+2025 Manutenção das Atividades da Controladoria Geral 
+Atividade mantida (percentual) 100 
+  
+2065 Manutenção dos Pagamentos de Precatórios Judiciais 
+Pagamentos mantida (percentual) 100 
+  
+2004 Manutenção das Atividades da Secretaria da Fazenda 
+ 
+Atividade mantida (percentual) 100 
+  
+
+FISCAL OBJETO EMPRESA 
+CONTRATO 
+PMMD 
+
+FONTE DE 
+RECURSO 
+
+STATUS 
+INICIO 
+(OS) 
+
+DATA DA 
+PARALIZAÇÃO 
+
+PRAZO DE 
+VIGÊNCIA 
+
+PRAZO DE 
+EXECUÇÃO 
+
+ADITIVO 
+PRAZO FINAL DE 
+VIGÊNCIA 
+
+PRAZO FINAL DE 
+EXECUÇÃO 
+
+FELIPE 
+Execução de construção de Miniquadra no anexo da escola 
+municipal Arlindo Estanislau no Município de Maragogi Al 
+
+CONATH EMPREENDIMENTOS E 
+INCORPORAÇÕES EIRELI 
+
+  
+30/2021 
+
+PROPRIO 
+EM 
+
+AMDAMENTO 
+07/04/21   365 90 300 07/04/2022 02/06/2024 
+
+FELIPE 
+Execução da construção de uma quadra poliesportiva na escola 
+
+Antônio Verçosa 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+31/2021 PROPRIO 
+
+EM 
+AMDAMENTO 
+
+07/04/21   365 120 300 07/04/2022 01/06/2022 
+
+LARYSSA Execução de Ampliação de cemitério publico 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+57/2021 PROPRIO PARALIZADO 31/05/21   720 90   31/05/2022 SALDO 420 DIAS 
+
+LUCAS 
+Prestação de serviços e Manutenção de vias de pavimentação 
+
+públicas e vicinais 
+FERRARI EMPREENDIMENTOS EIRELI 42/2021 PROPRIO 
+
+EM 
+AMDAMENTO 
+
+15/06/21   365 365   15/06/2022 15/06/2022 
+
+DIEGO/ 
+LARYSSA 
+
+Construção do sistema de abastecimento de água dos distritos 
+de peroba e ponta de mangue 
+
+CITE CONSULTORIA E 
+CONSTRUÇÕES EIRELI 
+
+52/2020 FEDERAL 
+EM 
+
+AMDAMENTO 
+09/07/20   730 720   08/07/2022 29/06/2022 
+
+LUCAS Unidade básica de saúde porte I carvão 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+51/2020 FEDERAL 
+
+EM 
+AMDAMENTO 
+
+01/07/20   720 180 180 21/06/2022 18/12/2022 
+
+LUCAS Centro de atendimento psicossocial CASP 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+70/2020 FEDERAL 
+
+EM 
+AMDAMENTO 
+
+15/12/20   545 300 240 13/06/2022 08/06/2022 
+
+ARTHUR Unidade de saúde familiar USF Alvim fontes 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+69/2020 FEDERAL PARALIZADO 15/12/20   545 120   13/06/2022 14/04/2023 
+
+FELIPE Campo de futebol de barra grande 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+110/2021 FEDERAL PARALIZADO           21/09/2022 23/05/2023 
+
+FELIPE Projeto do centro de convenções L & M SERVIÇOS   FEDERAL 
+EM 
+
+AMDAMENTO 
+              
+
+LARYSSA TERMINAL RODOVIÁRIO 
+CONATH EMPREENDIMENTOS E 
+
+INCORPORAÇÕES EIRELI 
+OR 06/12/21   
+
+EM 
+AMDAMENTO 
+
+06/12/21   365 180 0 23/09/2022 23/05/2022 
+
+  
 ESTADO DE ALAGOAS 
  
 PREFEITURA MUNICIPAL DE MARAGOGI 

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
@@ -2902,8 +2902,7 @@ AMDAMENTO
 
 06/12/21   365 180 0 23/09/2022 23/05/2022 
 
-  
-Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+  Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
 
 ESTADO DE ALAGOAS 
  

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
@@ -1,3 +1,5 @@
+Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+
 ESTADO DE ALAGOAS 
 PREFEITURA MUNICIPAL DE MARAGOGI 
 
@@ -2901,6 +2903,8 @@ AMDAMENTO
 06/12/21   365 180 0 23/09/2022 23/05/2022 
 
   
+Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+
 ESTADO DE ALAGOAS 
  
 PREFEITURA MUNICIPAL DE MARAGOGI 

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
@@ -1,3 +1,5 @@
+Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+
 ESTADO DE ALAGOAS 
 
 PREFEITURA MUNICIPAL DE SÃO LUIS DO QUITUNDE 
@@ -59,6 +61,8 @@ Genaldo Nascimento dos Santos
 Código Identificador:95AD7CE7 
 
  
+Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+
 ESTADO DE ALAGOAS 
 
 PREFEITURA MUNICIPAL DE SÃO LUIS DO QUITUNDE 

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
@@ -1,5 +1,64 @@
-Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+ESTADO DE ALAGOAS 
 
+PREFEITURA MUNICIPAL DE SÃO LUIS DO QUITUNDE 
+
+ 
+SETOR DE COMPRAS 
+
+PREFEITURA MUNICIPAL DE SÃO LUIZ DO QUITUNDE 
+ESTADO DE ALAGOAS SOLICITAÇÃO DE COTAÇÕES 
+
+ 
+A Prefeitura Municipal de São Luiz do Quitunde /AL, através do setor 
+de compras vem solicitar orçamentos, com o objetivo de pesquisas de 
+preços no mercado, uma vez que este é de suma importância para a 
+administração deste município, pois nele consiste o início do 
+procedimento legal para realização de futuras licitações. OBJETO: 
+DE CONTRAÇÃO DE EMPRESAS ESPECIALIZADAS 
+LOCAÇÃO DE TRANSPORTES PRAZO DE 48 HORAS PARA 
+O MUNICÍPIO DE SÃO LUIZ DO QUITUNDE/AL. Interessados 
+solicitar o anexo no e-mail: compras2019slq@gmail.com. 
+  
+São Luiz do Quitunde,26 AGOSTO de 2022. 
+ 
+  
+
+GENALDO NASCIMENTO DOS SANTOS 
+Setor de Compras   
+
+Publicado por: 
+Genaldo Nascimento dos Santos 
+
+Código Identificador:62766715 
+
+ 
+SETOR DE COMPRAS 
+
+PREFEITURA MUNICIPAL DE SÃO LUIZ DO QUITUNDE 
+ESTADO DE ALAGOAS SOLICITAÇÃO DE COTAÇÕES 
+
+ 
+A Prefeitura Municipal de São Luiz do Quitunde /AL, através do setor 
+de compras vem solicitar orçamentos, com o objetivo de pesquisas de 
+preços no mercado, uma vez que este é de suma importância para a 
+administração deste município, pois nele consiste o início do 
+procedimento legal para realização de futuras licitações. OBJETO: 
+DE CONTRAÇÃO DE EMPRESAS ESPECIALIZADAS 
+PUBLICIDADE PRAZO DE 48 HORAS PARA O MUNICÍPIO 
+DE SÃO LUIZ DO QUITUNDE/AL. Interessados solicitar o anexo 
+no e-mail: compras2019slq@gmail.com. 
+  
+São Luiz do Quitunde,26 AGOSTO de 2022. 
+  
+GENALDO NASCIMENTO DOS SANTOS 
+Setor de Compras  
+
+Publicado por: 
+Genaldo Nascimento dos Santos 
+
+Código Identificador:95AD7CE7 
+
+ 
 ESTADO DE ALAGOAS 
 
 PREFEITURA MUNICIPAL DE SÃO LUIS DO QUITUNDE 

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
@@ -60,8 +60,7 @@ Genaldo Nascimento dos Santos
 
 Código Identificador:95AD7CE7 
 
- 
-Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
+ Alagoas , 29 de Agosto de 2022   •   Diário Oficial dos Municípios do Estado de Alagoas   •    ANO IX | Nº 1869 
 
 ESTADO DE ALAGOAS 
 

--- a/post_proc.py
+++ b/post_proc.py
@@ -66,6 +66,10 @@ for municipio in lista_nomes_municipios:
     if f"{preffix}-proc-{municipio_proc}.txt" not in nomes_arquivos:
         nomes_arquivos.append(
             f"{preffix}-proc-{municipio_proc}.txt")
+# Inserindo o cabeçalho em cada município
+for municipio in lista_municipios:
+    municipio.insert(0, ama_header + "\n")
+
 dicionario_municipios = {}
 for (nome, municipio) in zip(lista_nomes_municipios, lista_municipios):
     chave = nome.strip().lower().replace(" ", "-")
@@ -77,9 +81,6 @@ for (nome, municipio) in zip(lista_nomes_municipios, lista_municipios):
             chave) + municipio
     else:
         dicionario_municipios[chave] = municipio
-# Inserindo o cabeçalho em cada município
-for municipio in lista_municipios:
-    municipio.insert(0, ama_header + "\n")
 
 # Escrevendo resultado
 for id, chave in zip(nomes_arquivos, dicionario_municipios.keys()):

--- a/post_proc.py
+++ b/post_proc.py
@@ -63,27 +63,20 @@ for municipio in lista_nomes_municipios:
     municipio_proc = municipio.strip().lower().replace(" ", "-")
     municipio_proc = unicodedata.normalize(
         'NFKD', municipio_proc).encode('ASCII', 'ignore').decode("utf-8")
-    if f"{preffix}-proc-{municipio_proc}.txt" not in nomes_arquivos:
-        nomes_arquivos.append(
-            f"{preffix}-proc-{municipio_proc}.txt")
+    nomes_arquivos.append(
+        f"{preffix}-proc-{municipio_proc}.txt")
+    
 # Inserindo o cabeçalho em cada município
 for municipio in lista_municipios:
     municipio.insert(0, ama_header + "\n")
 
-dicionario_municipios = {}
-for (nome, municipio) in zip(lista_nomes_municipios, lista_municipios):
-    chave = nome.strip().lower().replace(" ", "-")
-    chave = unicodedata.normalize('NFKD', chave).encode(
-        'ASCII', 'ignore').decode("utf-8")
-
-    if chave in dicionario_municipios.keys():
-        dicionario_municipios[chave] = dicionario_municipios.get(
-            chave) + municipio
-    else:
-        dicionario_municipios[chave] = municipio
+lista_nomes_municipios = {chave: '' for chave in nomes_arquivos}
+for (chave, municipio) in zip(nomes_arquivos, lista_municipios):
+    municipio = '\n'.join(municipio)
+    lista_nomes_municipios[chave] = lista_nomes_municipios[chave] + municipio
 
 # Escrevendo resultado
-for id, chave in zip(nomes_arquivos, dicionario_municipios.keys()):
+for id in nomes_arquivos:
     fname = id
     with open(fname, "w") as out_file:
-        out_file.write('\n'.join(dicionario_municipios.get(chave)))
+        out_file.write(lista_nomes_municipios.get(id))

--- a/post_proc.py
+++ b/post_proc.py
@@ -57,22 +57,32 @@ for num_linha, linha in enumerate(in_text_slice):
 
     if municipio:
         lista_municipios[qtd_municipios-1].append(linha)
-
-
 nomes_arquivos = []
 preffix = "-".join(in_file_name.split("-")[:-1])
 for municipio in lista_nomes_municipios:
     municipio_proc = municipio.strip().lower().replace(" ", "-")
     municipio_proc = unicodedata.normalize(
         'NFKD', municipio_proc).encode('ASCII', 'ignore').decode("utf-8")
-    nomes_arquivos.append(
-        f"{preffix}-proc-{municipio_proc}.txt")
+    if f"{preffix}-proc-{municipio_proc}.txt" not in nomes_arquivos:
+        nomes_arquivos.append(
+            f"{preffix}-proc-{municipio_proc}.txt")
+dicionario_municipios = {}
+for (nome, municipio) in zip(lista_nomes_municipios, lista_municipios):
+    chave = nome.strip().lower().replace(" ", "-")
+    chave = unicodedata.normalize('NFKD', chave).encode(
+        'ASCII', 'ignore').decode("utf-8")
 
+    if chave in dicionario_municipios.keys():
+        dicionario_municipios[chave] = dicionario_municipios.get(
+            chave) + municipio
+    else:
+        dicionario_municipios[chave] = municipio
 # Inserindo o cabeçalho em cada município
 for municipio in lista_municipios:
     municipio.insert(0, ama_header + "\n")
+
 # Escrevendo resultado
-for id, linhas in enumerate(lista_municipios):
-    fname = nomes_arquivos[id]
+for id, chave in zip(nomes_arquivos, dicionario_municipios.keys()):
+    fname = id
     with open(fname, "w") as out_file:
-        out_file.write('\n'.join(linhas))
+        out_file.write('\n'.join(dicionario_municipios.get(chave)))


### PR DESCRIPTION
Descobri fazendo esse código que Maragogi não foi o único que se repetiu, São Luís do Quitunde também e sem ser na mesma ordem. Então se você observar a lista nomes_arquivos ANTES das minhas modificações, ela conta com nomes repetidos, referentes às multiplas aparições de "ESTADO DE ALAGOAS" seguido de "PREFEITURA MUNICIPAL DE". 

Para resolver isso eu coloquei um if para que ele não adicionasse um nome que já existisse em nomes_arquivos. 
Depois eu criei uma estrutura de repetição for para montar o dicionário.