### PR TITLE
Remover Linhas Em Branco do Final de TODOS os Arquivos

### DIFF
--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-anadia.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-anadia.txt
@@ -121,6 +121,4 @@ Prefeito
 Publicado por: 
 Lucas Gabriel Vieira Almeida Rocha 
 
-Código Identificador:3AE50C8E 
-
- 
+Código Identificador:3AE50C8E

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-arapiraca.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-arapiraca.txt
@@ -85,6 +85,4 @@ no Município de Arapiraca.
 Publicado por: 
 Gean Fábio Carvalho de Oliveira 
 
-Código Identificador:D784B299 
-
- 
+Código Identificador:D784B299

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-atalaia.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-atalaia.txt
@@ -105,6 +105,4 @@ Secretário Municipal de Administração
 Publicado por: 
 Melry Dayane Cavalcante 
 
-Código Identificador:E03D1FD1 
-
- 
+Código Identificador:E03D1FD1

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-cacimbinhas.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-cacimbinhas.txt
@@ -143,6 +143,4 @@ Prefeito
 Publicado por: 
 Jose Fagner Targino Barbosa 
 
-Código Identificador:078D352E 
-
- 
+Código Identificador:078D352E

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-cajueiro.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-cajueiro.txt
@@ -26,6 +26,4 @@ Setor de Compras
 Publicado por: 
 Silvanio de Lima 
 
-Código Identificador:C51B4AA5 
-
- 
+Código Identificador:C51B4AA5

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-campo-alegre.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-campo-alegre.txt
@@ -351,6 +351,4 @@ Membro
 Publicado por: 
 Sâmara Mayra da Silva Ferreira 
 
-Código Identificador:213A26A4 
-
- 
+Código Identificador:213A26A4

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-canapi.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-canapi.txt
@@ -99,6 +99,4 @@ Presidente da CPL
 Publicado por: 
 Gilmo Malta de Menezes 
 
-Código Identificador:38910A84 
-
- 
+Código Identificador:38910A84

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-coqueiro-seco.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-coqueiro-seco.txt
@@ -133,6 +133,4 @@ Presidente da CPL
 Publicado por: 
 Ana Maria Soares da Silva 
 
-Código Identificador:D360D02F 
-
- 
+Código Identificador:D360D02F

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-craibas.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-craibas.txt
@@ -125,6 +125,4 @@ Nutricionista
 Publicado por: 
 Tiago José de Lima 
 
-Código Identificador:B4E23B2E 
-
- 
+Código Identificador:B4E23B2E

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-delmiro-gouveia.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-delmiro-gouveia.txt
@@ -138,6 +138,4 @@ Pregoeira.
 Publicado por: 
 Erika Vanessa Melo de Lima 
 
-Código Identificador:81CD5D63 
-
- 
+Código Identificador:81CD5D63

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-estrela-de-alagoas.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-estrela-de-alagoas.txt
@@ -51,6 +51,4 @@ Prefeito
 Publicado por: 
 Arnaldo de Araujo Alecio 
 
-Código Identificador:7898A0ED 
-
- 
+Código Identificador:7898A0ED

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-ibateguara.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-ibateguara.txt
@@ -25,6 +25,4 @@ Prefeita
 Publicado por: 
 Ana Claudia Duda 
 
-Código Identificador:22923EC8 
-
- 
+Código Identificador:22923EC8

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-jequia-da-praia.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-jequia-da-praia.txt
@@ -41,6 +41,4 @@ meses.
 Publicado por: 
 Jose Fabiano da Silva Santos 
 
-Código Identificador:A7F51F34 
-
- 
+Código Identificador:A7F51F34

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-junqueiro.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-junqueiro.txt
@@ -33,6 +33,4 @@ Presidente da CPL
 Publicado por: 
 Alex Junior Ferreira da Silva 
 
-Código Identificador:CC457CE8 
-
- 
+Código Identificador:CC457CE8

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maragogi.txt
@@ -2912,4 +2912,4 @@ SECRETARIA MUNICIPAL DE INFRAESTRUTURA
 Publicado por: 
 Djalma Juvêncio Lucas Neto 
 
-Código Identificador:B3EA75F9 
+Código Identificador:B3EA75F9

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maravilha.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maravilha.txt
@@ -64,6 +64,4 @@ Prefeita
 Publicado por: 
 Juan Rocha Soares 
 
-Código Identificador:6CA3BAA7 
-
- 
+Código Identificador:6CA3BAA7

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-marechal-deodoro.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-marechal-deodoro.txt
@@ -403,6 +403,4 @@ Setor de Compras e Contratos
 Publicado por: 
 Max Rogeres Ribeiro dos Santos 
 
-Código Identificador:FC5285E8 
-
- 
+Código Identificador:FC5285E8

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maribondo.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-maribondo.txt
@@ -69,6 +69,4 @@ Contratada
 
 Publicado por: 
 Grace Kelly dos Santos da Fonseca 
-Código Identificador:EE56D33F 
-
- 
+Código Identificador:EE56D33F

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-messias.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-messias.txt
@@ -39,6 +39,4 @@ Presidente da CPL
 Publicado por: 
 Jose Dolberon da Silva 
 
-Código Identificador:326065C3 
-
- 
+Código Identificador:326065C3

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-novo-lino.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-novo-lino.txt
@@ -69,6 +69,4 @@ Pregoeiro
 Publicado por: 
 Romisson Fagner Batista Barreto 
 
-Código Identificador:B5118E3F 
-
- 
+Código Identificador:B5118E3F

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-olho-d agua-do-casado.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-olho-d agua-do-casado.txt
@@ -112,6 +112,4 @@ Prefeito
 Publicado por: 
 Carla Maria de O Bezerra 
 
-Código Identificador:99E329FB 
-
- 
+Código Identificador:99E329FB

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-ouro-branco.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-ouro-branco.txt
@@ -179,6 +179,4 @@ Pregoeira
 Publicado por: 
 Natanael Feitosa da Silva Junior 
 
-Código Identificador:08B25E7F 
-
- 
+Código Identificador:08B25E7F

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-palestina.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-palestina.txt
@@ -39,6 +39,4 @@ cinco reais) – Vigência: 6 (seis) messes
 Publicado por: 
 Albert Leite e Silva 
 
-Código Identificador:80658506 
-
- 
+Código Identificador:80658506

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-pariconha.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-pariconha.txt
@@ -140,6 +140,4 @@ Prefeito
 Publicado por: 
 José Rodolfo da Silva Santos 
 
-Código Identificador:0D2BBC83 
-
- 
+Código Identificador:0D2BBC83

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-pilar.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-pilar.txt
@@ -42,6 +42,4 @@ LÊ SE: EXTRATO DA ATA DE REGISTRO DE PREÇOS Nº
 Publicado por: 
 Sérgio Lira de Oliveira 
 
-Código Identificador:98F1AE7F 
-
- 
+Código Identificador:98F1AE7F

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-piranhas.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-piranhas.txt
@@ -91,5 +91,4 @@ Código Identificador:895762B7
 
  
 
-www.diariomunicipal.com.br/ama                                                                                17 
- 
+www.diariomunicipal.com.br/ama                                                                                17

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-quebrangulo.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-quebrangulo.txt
@@ -71,6 +71,4 @@ de 2022.
 Publicado por: 
 Emerson de Souza Jatobá 
 
-Código Identificador:07B14657 
-
- 
+Código Identificador:07B14657

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-rio-largo.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-rio-largo.txt
@@ -277,6 +277,4 @@ MARIO LUCIO JUNIOR
 
 Publicado por: 
 Mario Lucio Gomes Maciel Junior 
-Código Identificador:8798FBB6 
-
- 
+Código Identificador:8798FBB6

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-santana-do-mundau.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-santana-do-mundau.txt
@@ -172,6 +172,4 @@ Presidente da CPL
 Publicado por: 
 Thiago de Farias Cunha Seixas 
 
-Código Identificador:7AACD450 
-
- 
+Código Identificador:7AACD450

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-jose-da-laje.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-jose-da-laje.txt
@@ -80,6 +80,4 @@ Chefe do Setor de Compras
 Publicado por: 
 Joelma Bezerra 
 
-Código Identificador:D9A281C7 
-
- 
+Código Identificador:D9A281C7

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-sao-luis-do-quitunde.txt
@@ -960,5 +960,4 @@ Código Identificador:2EE254DA
 
  
 
-www.diariomunicipal.com.br/ama                                                                                                                                     29 
- 
+www.diariomunicipal.com.br/ama                                                                                                                                     29

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-traipu.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-traipu.txt
@@ -37,6 +37,4 @@ Pregoeiro
 Publicado por: 
 Vitor Ribeiro dos Santos Cavalcanti 
 
-Código Identificador:4E20F758 
-
- 
+Código Identificador:4E20F758

--- a/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-vicosa.txt
+++ b/diario-completo-2022-08-29/diario-completo-2022-08-29-proc-vicosa.txt
@@ -465,6 +465,4 @@ Representante Legal/CONTRATADA
 Publicado por: 
 Katyucya Mychelly Silveira Calheiros Beserra 
 
-Código Identificador:2DFB3DEF 
-
- 
+Código Identificador:2DFB3DEF

--- a/post_proc.py
+++ b/post_proc.py
@@ -68,7 +68,7 @@ def extrai_diarios(texto_diario: str):
         diario.insert(0, ama_header + "\n")
 
     # Transformando o slice diãrio em texto e retornando.
-    return {nome_municipio: '\n'.join(diario) for nome_municipio, diario in diarios.items()}
+    return {nome_municipio: '\n'.join(diario).rstrip() for nome_municipio, diario in diarios.items()}
 
 
 def cria_arquivos(nome_arquivo_preffix: str, municipios: dict):


### PR DESCRIPTION
Mesmo com isso eu mantive o código que remove tudo depois do último código identificador porque tem alguns casos que existe um texto no final depois do último código identificador, como no caso do arquivo diario-completo-2022-08-29-extraido.txt. No final desse arquivo tem o nome de uma empresa disperso, que não é interessante manter no diário.